### PR TITLE
Apply Builder pattern and factory methods addressing issue #14066

### DIFF
--- a/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
+++ b/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
@@ -39,7 +39,7 @@ import org.controlsfx.control.textfield.AutoCompletionBinding;
 
 /**
  * Represents a binding between a text input control and an auto-completion popup
- * This class is a slightly modified version of {@link impl.org.controlsfx.autocompletion.AutoCompletionTextFieldBinding}
+ * This class is a slightly modified version of {@code impl.org.controlsfx.autocompletion.AutoCompletionTextFieldBinding}
  * that works with general text input controls instead of just text fields.
  */
 public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> {
@@ -47,8 +47,8 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
     /**
      * String converter to be used to convert suggestions to strings.
      */
-    private StringConverter<T> converter;
-    private AutoCompletionStrategy inputAnalyzer;
+    private final StringConverter<T> converter;
+    private final AutoCompletionStrategy inputAnalyzer;
     private final ChangeListener<String> textChangeListener = (_, _, newText) -> {
         if (getCompletionTarget().isFocused()) {
             setUserInputText(newText);
@@ -65,37 +65,58 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
         }
     };
 
-    /**
-     * Creates a new auto-completion binding between the given textInputControl
-     * and the given suggestion provider.
-     */
-    private AutoCompletionTextInputBinding(final TextInputControl textInputControl,
-                                           Callback<ISuggestionRequest, Collection<T>> suggestionProvider) {
-
-        this(textInputControl,
-                suggestionProvider,
-                AutoCompletionTextInputBinding.defaultStringConverter(),
-                new ReplaceStrategy());
-    }
-
-    private AutoCompletionTextInputBinding(final TextInputControl textInputControl,
-                                           final Callback<ISuggestionRequest, Collection<T>> suggestionProvider,
-                                           final StringConverter<T> converter) {
-        this(textInputControl, suggestionProvider, converter, new ReplaceStrategy());
-    }
-
-    private AutoCompletionTextInputBinding(final TextInputControl textInputControl,
-                                           final Callback<ISuggestionRequest, Collection<T>> suggestionProvider,
-                                           final StringConverter<T> converter,
-                                           final AutoCompletionStrategy inputAnalyzer) {
-
-        super(textInputControl, suggestionProvider, converter);
-        this.converter = converter;
-        this.inputAnalyzer = inputAnalyzer;
+    private AutoCompletionTextInputBinding(Builder<T> builder) {
+        super(builder.textInputControl, builder.suggestionProvider, builder.converter);
+        this.converter = builder.converter;
+        this.inputAnalyzer = builder.inputAnalyzer;
 
         getCompletionTarget().textProperty().addListener(textChangeListener);
         getCompletionTarget().focusedProperty().addListener(focusChangedListener);
     }
+
+    public static class Builder<T> {
+            // required parameters
+            private final TextInputControl textInputControl;
+            private final Callback<ISuggestionRequest, Collection<T>> suggestionProvider;
+
+            // optional parameter
+            private StringConverter<T> converter = AutoCompletionTextInputBinding.defaultStringConverter();
+            private AutoCompletionStrategy inputAnalyzer = new ReplaceStrategy();
+
+            /**
+             * Use a builder to create a new auto-completion binding between the given textInputControl
+             * and the given suggestion provider.
+             *
+             * @param textInputControl
+             * @param suggestionProvider
+             */
+            public Builder(TextInputControl textInputControl,
+                            Callback<ISuggestionRequest, Collection<T>> suggestionProvider) {
+                if (textInputControl == null || suggestionProvider == null) {
+                    throw new IllegalArgumentException("textInputControl and suggestionProvider must not be null");
+                }
+                this.textInputControl = textInputControl;
+                this.suggestionProvider = suggestionProvider;
+            }
+
+            public Builder<T> converter(StringConverter<T> c) {
+                if (c != null) {
+                    converter = c;
+                }
+                return this;
+            }
+
+            public Builder<T> inputAnalyzer(AutoCompletionStrategy acs) {
+                if (acs != null) {
+                    inputAnalyzer = acs;
+                }
+                return this;
+            }
+
+            public AutoCompletionTextInputBinding<T> build() {
+                return new AutoCompletionTextInputBinding<T>(this);
+            }
+        }
 
     private static <T> StringConverter<T> defaultStringConverter() {
         return new StringConverter<>() {
@@ -113,15 +134,15 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
     }
 
     public static <T> void autoComplete(TextInputControl textArea, Callback<ISuggestionRequest, Collection<T>> suggestionProvider) {
-        new AutoCompletionTextInputBinding<>(textArea, suggestionProvider);
+        new AutoCompletionTextInputBinding.Builder<T>(textArea, suggestionProvider).build();
     }
 
     public static <T> void autoComplete(TextInputControl textArea, Callback<ISuggestionRequest, Collection<T>> suggestionProvider, StringConverter<T> converter) {
-        new AutoCompletionTextInputBinding<>(textArea, suggestionProvider, converter);
+        new AutoCompletionTextInputBinding.Builder<T>(textArea, suggestionProvider).converter(converter).build();
     }
 
     public static <T> AutoCompletionTextInputBinding<T> autoComplete(TextInputControl textArea, Callback<ISuggestionRequest, Collection<T>> suggestionProvider, StringConverter<T> converter, AutoCompletionStrategy inputAnalyzer) {
-        return new AutoCompletionTextInputBinding<>(textArea, suggestionProvider, converter, inputAnalyzer);
+        return new AutoCompletionTextInputBinding.Builder<T>(textArea, suggestionProvider).converter(converter).inputAnalyzer(inputAnalyzer).build();
     }
 
     public static <T> AutoCompletionTextInputBinding<T> autoComplete(TextInputControl textArea, Callback<ISuggestionRequest, Collection<T>> suggestionProvider, AutoCompletionStrategy inputAnalyzer) {

--- a/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
+++ b/jabgui/src/main/java/org/jabref/gui/autocompleter/AutoCompletionTextInputBinding.java
@@ -74,6 +74,9 @@ public class AutoCompletionTextInputBinding<T> extends AutoCompletionBinding<T> 
         getCompletionTarget().focusedProperty().addListener(focusChangedListener);
     }
 
+    /**
+    *  Builder for AutoCompletionTextInputBinding.
+    */
     public static class Builder<T> {
             // required parameters
             private final TextInputControl textInputControl;

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtil.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtil.java
@@ -127,7 +127,7 @@ public class AutoSetFileLinksUtil {
 
                 String strType = type.map(ExternalFileType::getName).orElse("");
                 Path relativeFilePath = FileUtil.relativize(foundFile, directories);
-                LinkedFile linkedFile = new LinkedFile("", relativeFilePath, strType);
+                LinkedFile linkedFile = LinkedFile.of("", relativeFilePath, strType);
                 linkedFiles.add(linkedFile);
                 LOGGER.debug("Found file {} for entry {}", linkedFile, entry.getCitationKey());
             }

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/DownloadFullTextAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/DownloadFullTextAction.java
@@ -129,7 +129,7 @@ public class DownloadFullTextAction extends SimpleCommand {
      * @param entry           the entry "value"
      */
     private void addLinkedFileFromURL(BibDatabaseContext databaseContext, URL url, BibEntry entry) {
-        LinkedFile newLinkedFile = new LinkedFile(url, "");
+        LinkedFile newLinkedFile = LinkedFile.of(url, "");
 
         if (!entry.getFiles().contains(newLinkedFile)) {
             LinkedFileViewModel onlineFile = new LinkedFileViewModel(

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/ExternalFilesEntryLinker.java
@@ -49,7 +49,7 @@ public class ExternalFilesEntryLinker {
                                       .map(ext -> ExternalFileTypes.getExternalFileTypeByExt(ext, externalApplicationsPreferences).orElse(new UnknownExternalFileType(ext)).getName())
                                       .orElse("");
             Path relativePath = FileUtil.relativize(file, bibDatabaseContextSupplier.get(), filePreferences);
-            LinkedFile linkedFile = new LinkedFile("", relativePath, typeName);
+            LinkedFile linkedFile = LinkedFile.of("", relativePath, typeName);
 
             String link = linkedFile.getLink();
             boolean alreadyLinked = existingFiles.stream().anyMatch(existingFile -> existingFile.getLink().equals(link));
@@ -79,7 +79,7 @@ public class ExternalFilesEntryLinker {
             String typeName = FileUtil.getFileExtension(file)
                                       .map(ext -> ExternalFileTypes.getExternalFileTypeByExt(ext, externalApplicationsPreferences).orElse(new UnknownExternalFileType(ext)).getName())
                                       .orElse("");
-            LinkedFile linkedFile = new LinkedFile("", file, typeName);
+            LinkedFile linkedFile = LinkedFile.of("", file, typeName);
             LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entry, bibDatabaseContextSupplier.get(), filePreferences);
             try {
                 linkedFileHandler.copyOrMoveToDefaultDirectory(shouldMove, true);

--- a/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
+++ b/jabgui/src/main/java/org/jabref/gui/externalfiles/ImportHandler.java
@@ -499,12 +499,12 @@ public class ImportHandler {
             if (!entries.isEmpty()) {
                 entries.forEach(entry -> {
                     if (entry.getFiles().isEmpty()) {
-                        entry.addFile(new LinkedFile("", targetFile, StandardFileType.PDF.getName()));
+                        entry.addFile(LinkedFile.of("", targetFile, StandardFileType.PDF.getName()));
                     }
                 });
             } else {
                 BibEntry emptyEntry = new BibEntry();
-                emptyEntry.addFile(new LinkedFile("", targetFile, StandardFileType.PDF.getName()));
+                emptyEntry.addFile(LinkedFile.of("", targetFile, StandardFileType.PDF.getName()));
                 entries.add(emptyEntry);
             }
             return entries;

--- a/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/fieldeditors/LinkedFilesEditorViewModel.java
@@ -107,7 +107,7 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
         ExternalFileType suggestedFileType = ExternalFileTypes.getExternalFileTypeByExt(fileExtension, externalApplicationsPreferences)
                                                               .orElse(new UnknownExternalFileType(fileExtension));
         Path relativePath = FileUtil.relativize(file, fileDirectories);
-        return new LinkedFile("", relativePath, suggestedFileType.getName());
+        return LinkedFile.of("", relativePath, suggestedFileType.getName());
     }
 
     private void wireAggregateDownloadBindings() {
@@ -268,7 +268,7 @@ public class LinkedFilesEditorViewModel extends AbstractEditorViewModel {
 
     private void addFromURLAndDownload(URL url) {
         LinkedFileViewModel onlineFile = new LinkedFileViewModel(
-                new LinkedFile(url, ""),
+                LinkedFile.of(url, ""),
                 entry,
                 databaseContext,
                 taskExecutor,

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/AttachFileFromURLAction.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/AttachFileFromURLAction.java
@@ -63,7 +63,7 @@ public class AttachFileFromURLAction extends SimpleCommand {
         try {
             URL url = URLUtil.create(urlforDownload.get());
             LinkedFileViewModel onlineFile = new LinkedFileViewModel(
-                    new LinkedFile(url, ""),
+                    LinkedFile.of(url, ""),
                     entry,
                     databaseContext,
                     taskExecutor,

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialog.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialog.java
@@ -42,7 +42,7 @@ public class LinkedFileEditDialog extends BaseDialog<LinkedFile> {
      * Constructor for adding a new LinkedFile.
      */
     public LinkedFileEditDialog() {
-        this.linkedFile = new LinkedFile("", "", StandardFileType.PDF);
+        this.linkedFile = LinkedFile.of("", "", StandardFileType.PDF);
         initializeDialog(Localization.lang("Add file link"), ADD_BUTTON);
     }
 

--- a/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
+++ b/jabgui/src/main/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModel.java
@@ -170,12 +170,12 @@ public class LinkedFileEditDialogViewModel extends AbstractViewModel {
 
         if (LinkedFile.isOnlineLink(link.getValue())) {
             try {
-                return new LinkedFile(description.getValue(), URLUtil.create(link.getValue()), fileType, sourceUrl.getValue());
+                return LinkedFile.of(description.getValue(), URLUtil.create(link.getValue()), fileType, sourceUrl.getValue());
             } catch (MalformedURLException e) {
-                return new LinkedFile(description.getValue(), link.getValue(), fileType, sourceUrl.getValue());
+                return LinkedFile.of(description.getValue(), link.getValue(), fileType, sourceUrl.getValue());
             }
         }
-        return new LinkedFile(description.getValue(), Path.of(link.getValue()), fileType, sourceUrl.getValue());
+        return LinkedFile.of(description.getValue(), Path.of(link.getValue()), fileType, sourceUrl.getValue());
     }
 
     private String relativize(Path filePath) {

--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoRenameFileOnEntryChangeTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoRenameFileOnEntryChangeTest.java
@@ -88,7 +88,7 @@ class AutoRenameFileOnEntryChangeTest {
     @Test
     void noFileRenameByDefault() throws IOException {
         Files.createFile(tempDir.resolve("oldKey2081.pdf"));
-        entry.setFiles(List.of(new LinkedFile("", "oldKey2081.pdf", "PDF")));
+        entry.setFiles(List.of(LinkedFile.of("", "oldKey2081.pdf", "PDF")));
         entry.setField(StandardField.AUTHOR, "newKey");
 
         assertEquals("oldKey2081.pdf", entry.getFiles().getFirst().getLink());
@@ -98,7 +98,7 @@ class AutoRenameFileOnEntryChangeTest {
     @Test
     void noFileRenameOnEmptyFilePattern() throws IOException {
         Files.createFile(tempDir.resolve("oldKey2081.pdf"));
-        entry.setFiles(List.of(new LinkedFile("", "oldKey2081.pdf", "PDF")));
+        entry.setFiles(List.of(LinkedFile.of("", "oldKey2081.pdf", "PDF")));
         when(filePreferences.getFileNamePattern()).thenReturn("");
         when(filePreferences.shouldAutoRenameFilesOnChange()).thenReturn(true);
         entry.setField(StandardField.AUTHOR, "newKey");
@@ -110,7 +110,7 @@ class AutoRenameFileOnEntryChangeTest {
     @Test
     void singleFileRenameOnEntryChange() throws IOException {
         Files.createFile(tempDir.resolve("oldKey2081.pdf"));
-        entry.setFiles(List.of(new LinkedFile("", "oldKey2081.pdf", "PDF")));
+        entry.setFiles(List.of(LinkedFile.of("", "oldKey2081.pdf", "PDF")));
         when(filePreferences.shouldAutoRenameFilesOnChange()).thenReturn(true);
 
         // change author only
@@ -140,11 +140,11 @@ class AutoRenameFileOnEntryChangeTest {
             Files.createFile(filePath);
         }
 
-        LinkedFile pdfLinkedFile = new LinkedFile("", "oldKey2081.pdf", "PDF");
-        LinkedFile jpgLinkedFile = new LinkedFile("", "oldKey2081.jpg", "JPG");
-        LinkedFile csvLinkedFile = new LinkedFile("", "oldKey2081.csv", "CSV");
-        LinkedFile docLinkedFile = new LinkedFile("", "oldKey2081.doc", "DOC");
-        LinkedFile docxLinkedFile = new LinkedFile("", "oldKey2081.docx", "DOCX");
+        LinkedFile pdfLinkedFile = LinkedFile.of("", "oldKey2081.pdf", "PDF");
+        LinkedFile jpgLinkedFile = LinkedFile.of("", "oldKey2081.jpg", "JPG");
+        LinkedFile csvLinkedFile = LinkedFile.of("", "oldKey2081.csv", "CSV");
+        LinkedFile docLinkedFile = LinkedFile.of("", "oldKey2081.doc", "DOC");
+        LinkedFile docxLinkedFile = LinkedFile.of("", "oldKey2081.docx", "DOCX");
 
         entry.setFiles(List.of(pdfLinkedFile, jpgLinkedFile, csvLinkedFile, docLinkedFile, docxLinkedFile));
         when(filePreferences.shouldAutoRenameFilesOnChange()).thenReturn(true);
@@ -173,7 +173,7 @@ class AutoRenameFileOnEntryChangeTest {
         Files.createFile(tempDir.resolve("newKey2081 (1).pdf"));
 
         Files.createFile(tempDir.resolve("oldKey2081.pdf"));
-        entry.setFiles(List.of(new LinkedFile("", "oldKey2081.pdf", "PDF")));
+        entry.setFiles(List.of(LinkedFile.of("", "oldKey2081.pdf", "PDF")));
         when(filePreferences.shouldAutoRenameFilesOnChange()).thenReturn(true);
 
         entry.setField(StandardField.AUTHOR, "newKey");

--- a/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiles/AutoSetFileLinksUtilTest.java
@@ -52,7 +52,7 @@ class AutoSetFileLinksUtilTest {
     @Test
     void findAssociatedNotLinkedFilesSuccess() throws IOException {
         when(databaseContext.getFileDirectories(any())).thenReturn(List.of(path.getParent()));
-        List<LinkedFile> expected = List.of(new LinkedFile("", Path.of("CiteKey.pdf"), "PDF"));
+        List<LinkedFile> expected = List.of(LinkedFile.of("", Path.of("CiteKey.pdf"), "PDF"));
         AutoSetFileLinksUtil util = new AutoSetFileLinksUtil(databaseContext, externalApplicationsPreferences, filePreferences, autoLinkPrefs);
         List<LinkedFile> actual = util.findAssociatedNotLinkedFiles(entry);
         assertEquals(expected, actual);
@@ -73,7 +73,7 @@ class AutoSetFileLinksUtilTest {
         Files.createDirectories(oldPath.getParent());
         Files.createFile(oldPath);
 
-        LinkedFile stale = new LinkedFile("", oldPath.toString(), "PDF");
+        LinkedFile stale = LinkedFile.of("", oldPath.toString(), "PDF");
         BibEntry entry = new BibEntry(StandardEntryType.Misc);
         entry.addFile(stale);
 

--- a/jabgui/src/test/java/org/jabref/gui/externalfiletype/ExternalFileTypesTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/externalfiletype/ExternalFileTypesTest.java
@@ -89,7 +89,7 @@ class ExternalFileTypesTest {
 
     @Test
     void getExternalFileTypeByLinkedFile() {
-        LinkedFile testfile = new LinkedFile("A testfile", "https://testserver.com/testfile.pdf", "PDF");
+        LinkedFile testfile = LinkedFile.of("A testfile", "https://testserver.com/testfile.pdf", "PDF");
         assertEquals(Optional.of(StandardExternalFileType.PDF), ExternalFileTypes.getExternalFileTypeByLinkedFile(testfile, false, externalApplicationsPreferences));
     }
 

--- a/jabgui/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/fieldeditors/LinkedFileViewModelTest.java
@@ -105,7 +105,7 @@ class LinkedFileViewModelTest {
     @Test
     void deleteWhenFilePathNotPresentReturnsTrue() {
         // Making this a spy, so we can inject an empty optional without digging into the implementation
-        linkedFile = spy(new LinkedFile("", Path.of("nonexistent file"), ""));
+        linkedFile = spy(LinkedFile.of("", Path.of("nonexistent file"), ""));
         doReturn(Optional.empty()).when(linkedFile).findIn(any(BibDatabaseContext.class), any(FilePreferences.class));
 
         LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, taskExecutor, dialogService, preferences);
@@ -119,7 +119,7 @@ class LinkedFileViewModelTest {
 
     @Test
     void deleteWhenRemoveChosenReturnsTrueButDoesNotDeletesFile() {
-        linkedFile = new LinkedFile("", tempFile, "");
+        linkedFile = LinkedFile.of("", tempFile, "");
         // Mock the dialog created at {@link org.jabref.gui.linkedfile.DeleteFileAction.execute}
         when(dialogService.showCustomDialogAndWait(
                 anyString(),
@@ -137,7 +137,7 @@ class LinkedFileViewModelTest {
 
     @Test
     void deleteWhenDeleteChosenReturnsTrueAndDeletesFile() {
-        linkedFile = new LinkedFile("", tempFile, "");
+        linkedFile = LinkedFile.of("", tempFile, "");
         when(dialogService.showCustomDialogAndWait(
                 anyString(),
                 any(DialogPane.class),
@@ -154,7 +154,7 @@ class LinkedFileViewModelTest {
 
     @Test
     void deleteMissingFileReturnsTrue() {
-        linkedFile = new LinkedFile("", Path.of("!!nonexistent file!!"), "");
+        linkedFile = LinkedFile.of("", Path.of("!!nonexistent file!!"), "");
         when(dialogService.showCustomDialogAndWait(
                 anyString(),
                 any(DialogPane.class),
@@ -170,7 +170,7 @@ class LinkedFileViewModelTest {
 
     @Test
     void deleteWhenDialogCancelledReturnsFalseAndDoesNotRemoveFile() {
-        linkedFile = new LinkedFile("desc", tempFile, "pdf");
+        linkedFile = LinkedFile.of("desc", tempFile, "pdf");
         when(dialogService.showCustomDialogAndWait(
                 anyString(),
                 any(DialogPane.class),
@@ -198,7 +198,7 @@ class LinkedFileViewModelTest {
 
         URL url = URLUtil.create("https://www.google.com/");
         String fileType = StandardExternalFileType.URL.getName();
-        linkedFile = new LinkedFile(url, fileType);
+        linkedFile = LinkedFile.of(url, fileType);
 
         LinkedFileViewModel viewModel = new LinkedFileViewModel(linkedFile, entry, databaseContext, new CurrentThreadTaskExecutor(), dialogService, preferences);
 
@@ -209,7 +209,7 @@ class LinkedFileViewModelTest {
 
     @Test
     void isNotSamePath() {
-        linkedFile = new LinkedFile("desc", tempFile, "pdf");
+        linkedFile = LinkedFile.of("desc", tempFile, "pdf");
         databaseContext = mock(BibDatabaseContext.class);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -221,7 +221,7 @@ class LinkedFileViewModelTest {
 
     @Test
     void isSamePath() {
-        linkedFile = new LinkedFile("desc", tempFile, "pdf");
+        linkedFile = LinkedFile.of("desc", tempFile, "pdf");
         databaseContext = mock(BibDatabaseContext.class);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -234,7 +234,7 @@ class LinkedFileViewModelTest {
     // Tests if isGeneratedPathSameAsOriginal takes into consideration File directory pattern
     @Test
     void isNotSamePathWithPattern() {
-        linkedFile = new LinkedFile("desc", tempFile, "pdf");
+        linkedFile = LinkedFile.of("desc", tempFile, "pdf");
         databaseContext = mock(BibDatabaseContext.class);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("[entrytype]");
@@ -247,7 +247,7 @@ class LinkedFileViewModelTest {
     // Tests if isGeneratedPathSameAsOriginal takes into consideration File directory pattern
     @Test
     void isSamePathWithPattern() throws IOException {
-        linkedFile = new LinkedFile("desc", tempFile, "pdf");
+        linkedFile = LinkedFile.of("desc", tempFile, "pdf");
         databaseContext = mock(BibDatabaseContext.class);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("[entrytype]");
@@ -273,7 +273,7 @@ class LinkedFileViewModelTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void downloadPdfFileWhenLinkedFilePointsToPdfUrl(boolean keepHtml) throws MalformedURLException {
-        linkedFile = new LinkedFile(URLUtil.create("http://arxiv.org/pdf/1207.0408v1"), "pdf");
+        linkedFile = LinkedFile.of(URLUtil.create("http://arxiv.org/pdf/1207.0408v1"), "pdf");
         // Needed Mockito stubbing methods to run test
         when(filePreferences.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");

--- a/jabgui/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/linkedfile/DownloadLinkedFileActionTest.java
@@ -95,7 +95,7 @@ class DownloadLinkedFileActionTest {
     void replacesLinkedFiles(@TempDir Path tempFolder) throws MalformedURLException {
         String url = "http://arxiv.org/pdf/1207.0408v1";
 
-        LinkedFile linkedFile = new LinkedFile(URLUtil.create(url), "");
+        LinkedFile linkedFile = LinkedFile.of(URLUtil.create(url), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -112,7 +112,7 @@ class DownloadLinkedFileActionTest {
                 new CurrentThreadTaskExecutor());
         downloadLinkedFileAction.execute();
 
-        assertEquals(List.of(new LinkedFile("", tempFolder.resolve("asdf.pdf"), "PDF", url)), entry.getFiles());
+        assertEquals(List.of(LinkedFile.of("", tempFolder.resolve("asdf.pdf"), "PDF", url)), entry.getFiles());
     }
 
     @ParameterizedTest
@@ -120,7 +120,7 @@ class DownloadLinkedFileActionTest {
     void doesntReplaceSourceURL(boolean keepHtml) throws IOException {
         String url = "http://arxiv.org/pdf/1207.0408v1";
 
-        LinkedFile linkedFile = new LinkedFile(URLUtil.create(url), "");
+        LinkedFile linkedFile = LinkedFile.of(URLUtil.create(url), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -137,7 +137,7 @@ class DownloadLinkedFileActionTest {
                 new CurrentThreadTaskExecutor());
         downloadLinkedFileAction.execute();
 
-        assertEquals(List.of(new LinkedFile("", tempFolder.resolve("asdf.pdf"), "PDF", url)), entry.getFiles());
+        assertEquals(List.of(LinkedFile.of("", tempFolder.resolve("asdf.pdf"), "PDF", url)), entry.getFiles());
 
         linkedFile = entry.getFiles().getFirst();
 
@@ -159,7 +159,7 @@ class DownloadLinkedFileActionTest {
                 keepHtml);
         downloadLinkedFileAction2.execute();
 
-        assertEquals(List.of(new LinkedFile("", tempFolder.resolve("asdf.pdf"), "PDF", url)), entry.getFiles());
+        assertEquals(List.of(LinkedFile.of("", tempFolder.resolve("asdf.pdf"), "PDF", url)), entry.getFiles());
     }
 
     @Test
@@ -175,7 +175,7 @@ class DownloadLinkedFileActionTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html; charset=utf-8")));
 
-        LinkedFile linkedFile = new LinkedFile(URLUtil.create("http://localhost:2331/html"), "");
+        LinkedFile linkedFile = LinkedFile.of(URLUtil.create("http://localhost:2331/html"), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
@@ -211,7 +211,7 @@ class DownloadLinkedFileActionTest {
                         .withStatus(200)
                         .withHeader("Content-Type", "text/html; charset=utf-8")));
 
-        LinkedFile linkedFile = new LinkedFile(URLUtil.create("http://localhost:2331/html"), "");
+        LinkedFile linkedFile = LinkedFile.of(URLUtil.create("http://localhost:2331/html"), "");
         when(databaseContext.getFirstExistingFileDir(any())).thenReturn(Optional.of(tempFolder));
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");

--- a/jabgui/src/test/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModelTest.java
+++ b/jabgui/src/test/java/org/jabref/gui/linkedfile/LinkedFileEditDialogViewModelTest.java
@@ -48,11 +48,11 @@ class LinkedFileEditDialogViewModelTest {
         Files.createFile(invalidFile);
         when(dialogService.showConfirmationDialogAndWait(any(), any(), any())).thenReturn(true);
 
-        LinkedFileEditDialogViewModel viewModel = new LinkedFileEditDialogViewModel(new LinkedFile("", "", ""), bibDatabaseContext, dialogService, externalApplicationsPreferences, filePreferences);
+        LinkedFileEditDialogViewModel viewModel = new LinkedFileEditDialogViewModel(LinkedFile.of("", "", ""), bibDatabaseContext, dialogService, externalApplicationsPreferences, filePreferences);
 
         viewModel.checkForBadFileNameAndAdd(invalidFile);
 
-        LinkedFile expectedFile = new LinkedFile("", tempDir.resolve("_invalid.pdf").toString(), "PDF");
+        LinkedFile expectedFile = LinkedFile.of("", tempDir.resolve("_invalid.pdf").toString(), "PDF");
         assertEquals(expectedFile, viewModel.getNewLinkedFile());
     }
 }

--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -24,6 +24,8 @@ plugins {
 
     id("net.ltgt.errorprone") version "4.3.0"
     id("net.ltgt.nullaway") version "2.3.0"
+
+    id("com.github.spotbugs") version "6.4.2"
 }
 
 var version: String = project.findProperty("projVersion")?.toString() ?: "0.1.0"
@@ -45,6 +47,17 @@ configurations {
 }
 tasks.withType<com.autonomousapps.tasks.CodeSourceExploderTask>().configureEach {
     dependsOn(tasks.withType<AntlrTask>())
+}
+
+tasks.withType(com.github.spotbugs.snom.SpotBugsTask::class).configureEach {
+    reports {
+        create("html") {
+            required.set(true)
+        }
+        create("text") {
+            required.set(false)
+        }
+    }
 }
 
 // See https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3

--- a/jablib/build.gradle.kts
+++ b/jablib/build.gradle.kts
@@ -24,8 +24,6 @@ plugins {
 
     id("net.ltgt.errorprone") version "4.3.0"
     id("net.ltgt.nullaway") version "2.3.0"
-
-    id("com.github.spotbugs") version "6.4.2"
 }
 
 var version: String = project.findProperty("projVersion")?.toString() ?: "0.1.0"
@@ -47,17 +45,6 @@ configurations {
 }
 tasks.withType<com.autonomousapps.tasks.CodeSourceExploderTask>().configureEach {
     dependsOn(tasks.withType<AntlrTask>())
-}
-
-tasks.withType(com.github.spotbugs.snom.SpotBugsTask::class).configureEach {
-    reports {
-        create("html") {
-            required.set(true)
-        }
-        create("text") {
-            required.set(false)
-        }
-    }
 }
 
 // See https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3

--- a/jablib/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
+++ b/jablib/src/main/java/org/jabref/logic/cleanup/RelativePathsCleanup.java
@@ -44,7 +44,7 @@ public class RelativePathsCleanup implements CleanupJob {
             }
             LinkedFile newFileEntry = fileEntry;
             if (!oldFileName.equals(newFileName)) {
-                newFileEntry = new LinkedFile(fileEntry.getDescription(), Path.of(newFileName), fileEntry.getFileType());
+                newFileEntry = LinkedFile.of(fileEntry.getDescription(), Path.of(newFileName), fileEntry.getFileType());
                 changed = true;
             }
             newFileList.add(newFileEntry);

--- a/jablib/src/main/java/org/jabref/logic/cleanup/UpgradePdfPsToFileCleanup.java
+++ b/jablib/src/main/java/org/jabref/logic/cleanup/UpgradePdfPsToFileCleanup.java
@@ -41,7 +41,7 @@ public class UpgradePdfPsToFileCleanup implements CleanupJob {
                     return;
                 }
                 Path path = Path.of(fieldContent);
-                LinkedFile flEntry = new LinkedFile(path.getFileName().toString(), path, field.getValue());
+                LinkedFile flEntry = LinkedFile.of(path.getFileName().toString(), path, field.getValue());
                 fileList.add(flEntry);
 
                 entry.clearField(field.getKey());

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/ArXivFetcher.java
@@ -778,7 +778,7 @@ public class ArXivFetcher implements FulltextFetcher, PagedSearchBasedFetcher, I
                 getDate().ifPresent(date -> bibEntry.setField(StandardField.DATE, date));
                 primaryCategory.ifPresent(category -> bibEntry.setField(StandardField.EPRINTCLASS, category));
                 journalReferenceText.ifPresent(journal -> bibEntry.setField(StandardField.JOURNAL, journal));
-                getPdfUrl().ifPresent(url -> bibEntry.setFiles(List.of(new LinkedFile(url, "PDF"))));
+                getPdfUrl().ifPresent(url -> bibEntry.setFiles(List.of(LinkedFile.of(url, "PDF"))));
                 return bibEntry;
             }
         }

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/IEEE.java
@@ -124,7 +124,7 @@ public class IEEE implements FulltextFetcher, PagedSearchBasedParserFetcher, Cus
         entry.setField(StandardField.ISSUE, jsonEntry.optString("issue"));
         String pdfUrl = jsonEntry.optString("pdf_url");
         if (!StringUtil.isBlank(pdfUrl)) {
-            entry.addFile(new LinkedFile("", pdfUrl, "PDF"));
+            entry.addFile(LinkedFile.of("", pdfUrl, "PDF"));
         }
         entry.setField(StandardField.JOURNALTITLE, jsonEntry.optString("publication_title"));
         entry.setField(StandardField.DATE, jsonEntry.optString("publication_date"));

--- a/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fetcher/SpringerNatureWebFetcher.java
@@ -128,7 +128,7 @@ public class SpringerNatureWebFetcher implements PagedSearchBasedParserFetcher, 
                     JSONObject url = (JSONObject) data;
                     if ("pdf".equalsIgnoreCase(url.optString("format"))) {
                         try {
-                            entry.addFile(new LinkedFile(URLUtil.create(url.optString("value")), "PDF"));
+                            entry.addFile(LinkedFile.of(URLUtil.create(url.optString("value")), "PDF"));
                         } catch (MalformedURLException e) {
                             LOGGER.info("Malformed URL: {}", url.optString("value"));
                         }

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -791,14 +791,14 @@ public class BibtexParser implements Parser {
                             NSString relativePath = (NSString) plist.objectForKey("relativePath");
                             Path path = Path.of(relativePath.getContent());
 
-                            LinkedFile file = new LinkedFile("", path, "");
+                            LinkedFile file = LinkedFile.of("", path, "");
                             entry.addFile(file);
                         } else if (plist.containsKey("$objects") && plist.objectForKey("$objects") instanceof NSArray nsArray) {
                             if (nsArray.getArray().length > INDEX_RELATIVE_PATH_IN_PLIST) {
                                 NSString relativePath = (NSString) nsArray.objectAtIndex(INDEX_RELATIVE_PATH_IN_PLIST);
                                 Path path = Path.of(relativePath.getContent());
 
-                                LinkedFile file = new LinkedFile("", path, "");
+                                LinkedFile file = LinkedFile.of("", path, "");
                                 entry.addFile(file);
                             }
                         } else {

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/MarcXmlParser.java
@@ -402,7 +402,7 @@ public class MarcXmlParser implements Parser {
     private static void handleVolltext(BibEntry bibEntry, String fieldName, String resource, Field fallBackField) {
         if ("Volltext".equals(fieldName) && StringUtil.isNotBlank(resource)) {
             try {
-                LinkedFile linkedFile = new LinkedFile("", URLUtil.create(resource), StandardFileType.PDF.getName());
+                LinkedFile linkedFile = LinkedFile.of("", URLUtil.create(resource), StandardFileType.PDF.getName());
                 bibEntry.setFiles(List.of(linkedFile));
             } catch (MalformedURLException | IllegalArgumentException e) {
                 LOGGER.info("Malformed URL: {}", resource);

--- a/jablib/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/fileformat/PdfMergeMetadataImporter.java
@@ -97,7 +97,7 @@ public class PdfMergeMetadataImporter extends PdfImporter {
 
         // We use the absolute path here as we do not know the context where this import will be used.
         // The caller is responsible for making the path relative if necessary.
-        entry.addFile(new LinkedFile("", filePath, StandardFileType.PDF.getName()));
+        entry.addFile(LinkedFile.of("", filePath, StandardFileType.PDF.getName()));
         return List.of(entry);
     }
 

--- a/jablib/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
+++ b/jablib/src/main/java/org/jabref/logic/importer/util/FileFieldParser.java
@@ -59,7 +59,7 @@ public class FileFieldParser {
         if (LinkedFile.isOnlineLink(value.trim())) {
             // needs to be modifiable
             try {
-                return List.of(new LinkedFile(URLUtil.create(value), ""));
+                return List.of(LinkedFile.of(URLUtil.create(value), ""));
             } catch (MalformedURLException e) {
                 LOGGER.error("invalid url", e);
                 return files;
@@ -157,25 +157,25 @@ public class FileFieldParser {
         LinkedFile field = null;
         if (LinkedFile.isOnlineLink(entry.get(1))) {
             try {
-                field = new LinkedFile(entry.getFirst(), URLUtil.create(entry.get(1)), entry.get(2));
+                field = LinkedFile.of(entry.getFirst(), URLUtil.create(entry.get(1)), entry.get(2));
             } catch (MalformedURLException e) {
                 // in case the URL is malformed, store it nevertheless
-                field = new LinkedFile(entry.getFirst(), entry.get(1), entry.get(2));
+                field = LinkedFile.of(entry.getFirst(), entry.get(1), entry.get(2));
             }
         } else {
             String pathStr = entry.get(1);
             if (pathStr.contains("//")) {
                 // In case the path contains //, we assume it is a malformed URL, not a malformed path.
                 // On linux, the double slash would be converted to a single slash.
-                field = new LinkedFile(entry.getFirst(), pathStr, entry.get(2));
+                field = LinkedFile.of(entry.getFirst(), pathStr, entry.get(2));
             } else {
                 try {
                     // there is no Path.isValidPath(String) method
-                    field = new LinkedFile(entry.getFirst(), Path.of(pathStr), entry.get(2));
+                    field = LinkedFile.of(entry.getFirst(), Path.of(pathStr), entry.get(2));
                 } catch (InvalidPathException e) {
                     // Ignored
                     LOGGER.debug("Invalid path object, continuing with string", e);
-                    field = new LinkedFile(entry.getFirst(), pathStr, entry.get(2));
+                    field = LinkedFile.of(entry.getFirst(), pathStr, entry.get(2));
                 }
             }
         }
@@ -186,9 +186,9 @@ public class FileFieldParser {
 
         // link is the only mandatory field
         if (field.getDescription().isEmpty() && field.getLink().isEmpty() && !field.getFileType().isEmpty()) {
-            field = new LinkedFile("", Path.of(field.getFileType()), "");
+            field = LinkedFile.of("", Path.of(field.getFileType()), "");
         } else if (!field.getDescription().isEmpty() && field.getLink().isEmpty() && field.getFileType().isEmpty()) {
-            field = new LinkedFile("", Path.of(field.getDescription()), "");
+            field = LinkedFile.of("", Path.of(field.getDescription()), "");
         }
         entry.clear();
         return field;

--- a/jablib/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
+++ b/jablib/src/main/java/org/jabref/logic/xmp/XmpUtilReader.java
@@ -113,7 +113,7 @@ public class XmpUtilReader {
             }
         });
 
-        result.forEach(entry -> entry.addFile(new LinkedFile("", path, "PDF")));
+        result.forEach(entry -> entry.addFile(LinkedFile.of("", path, "PDF")));
 
         return result.stream().toList();
     }

--- a/jablib/src/main/java/org/jabref/model/database/BibDatabaseContext.java
+++ b/jablib/src/main/java/org/jabref/model/database/BibDatabaseContext.java
@@ -68,30 +68,74 @@ public class BibDatabaseContext {
     private CoarseChangeFilter dbmsListener;
     private DatabaseLocation location;
 
-    public BibDatabaseContext() {
-        this(new BibDatabase());
-    }
-
-    public BibDatabaseContext(@NonNull BibDatabase database) {
-        this(database, new MetaData());
-    }
-
-    public BibDatabaseContext(@NonNull BibDatabase database, @NonNull MetaData metaData) {
-        this.database = database;
-        this.metaData = metaData;
-        this.location = DatabaseLocation.LOCAL;
-    }
-
-    public BibDatabaseContext(@NonNull BibDatabase database, @NonNull MetaData metaData, Path path) {
-        this(database, metaData, path, DatabaseLocation.LOCAL);
-    }
-
-    public BibDatabaseContext(@NonNull BibDatabase database, @NonNull MetaData metaData, Path path, @NonNull DatabaseLocation location) {
-        this(database, metaData);
-        this.path = path;
+    private BibDatabaseContext(Builder builder) {
+        this.database = builder.database;
+        this.metaData = builder.metaData;
+        this.location = builder.location;
+        this.path = builder.path;
 
         if (location == DatabaseLocation.LOCAL) {
             convertToLocalDatabase();
+        }
+    }
+
+    public BibDatabaseContext() {
+        this(new Builder(new BibDatabase()));
+    }
+
+    public BibDatabaseContext(@NonNull BibDatabase database) {
+        this(new Builder(database).metaData(new MetaData()));
+    }
+
+    public BibDatabaseContext(@NonNull BibDatabase database, @NonNull MetaData metaData) {
+        this(new Builder(database).metaData(metaData).location(DatabaseLocation.LOCAL));
+    }
+
+    public BibDatabaseContext(@NonNull BibDatabase database, @NonNull MetaData metaData, Path path) {
+        this(new Builder(database).metaData(metaData).location(DatabaseLocation.LOCAL).path(path));
+    }
+
+    public BibDatabaseContext(@NonNull BibDatabase database, @NonNull MetaData metaData, Path path, @NonNull DatabaseLocation location) {
+        this(new Builder(database).metaData(metaData).location(location).path(path));
+    }
+
+    public static class Builder {
+        // required parameters
+        private final BibDatabase database;
+
+        // optional parameters with default values
+        private MetaData metaData = new MetaData();
+        private Path path;
+        private DatabaseLocation location = DatabaseLocation.LOCAL;
+
+        public Builder(BibDatabase database) {
+            if (database == null) {
+                throw new IllegalArgumentException("database must not be null");
+            }
+            this.database = database;
+        }
+
+        public Builder metaData(MetaData md) {
+            if (md != null) {
+                metaData = md;
+            }
+            return this;
+        }
+
+        public Builder path(Path p) {
+            path = p;
+            return this;
+        }
+
+        public Builder location(DatabaseLocation l) {
+            if (l != null) {
+                location = l;
+            }
+            return this;
+        }
+
+        public BibDatabaseContext build() {
+            return new BibDatabaseContext(this);
         }
     }
 
@@ -305,7 +349,7 @@ public class BibDatabaseContext {
     }
 
     public static BibDatabaseContext empty() {
-        return new BibDatabaseContext(new BibDatabase(), new MetaData());
+        return new BibDatabaseContext.Builder(new BibDatabase()).metaData(new MetaData()).build();
     }
 
     @Override

--- a/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
+++ b/jablib/src/main/java/org/jabref/model/entry/LinkedFile.java
@@ -39,7 +39,7 @@ public class LinkedFile implements Serializable {
     private static final String REGEX_URL = "^((?:https?\\:\\/\\/|www\\.)(?:[-a-z0-9]+\\.)*[-a-z0-9]+.*)";
     private static final Pattern URL_PATTERN = Pattern.compile(REGEX_URL);
 
-    private static final LinkedFile NULL_OBJECT = new LinkedFile("", Path.of(""), "");
+    private static final LinkedFile NULL_OBJECT = LinkedFile.of("", Path.of("").toString(), "", "");
 
     // We have to mark these properties as transient because they can't be serialized directly
     private transient StringProperty description = new SimpleStringProperty();
@@ -49,49 +49,53 @@ public class LinkedFile implements Serializable {
     private transient StringProperty fileType = new SimpleStringProperty();
     private transient StringProperty sourceURL = new SimpleStringProperty();
 
-    public LinkedFile(String description, Path link, String fileType) {
-        this(description, link.toString(), fileType);
-    }
-
-    public LinkedFile(String description, Path link, String fileType, String sourceUrl) {
-        this(description, link.toString(), fileType, sourceUrl);
-    }
-
-    public LinkedFile(String description, String link, FileType fileType) {
-        this(description, link, fileType.getName());
-    }
-
     /**
      * Constructor can also be used for non-valid paths. We need to parse them, because the GUI needs to render it.
      */
-    public LinkedFile(String description, String link, String fileType, String sourceUrl) {
+    private LinkedFile(String description, String link, String fileType, String sourceUrl) {
         this.description.setValue(description);
         setLink(link);
         this.fileType.setValue(fileType);
         this.sourceURL.setValue(sourceUrl);
     }
 
-    public LinkedFile(String description, String link, String fileType) {
-        this(description, link, fileType, "");
+    public static LinkedFile of(String description, Path link, String fileType) {
+        return new LinkedFile(description, link.toString(), fileType, "");
     }
 
-    public LinkedFile(URL link, String fileType) {
-        this("", link.toString(), fileType);
+    public static LinkedFile of(String description, Path link, String fileType, String sourceUrl) {
+        return new LinkedFile(description, link.toString(), fileType, sourceUrl);
     }
 
-    public LinkedFile(String description, URL link, String fileType) {
-        this(description, link.toString(), fileType);
+    public static LinkedFile of(String description, String link, FileType fileType) {
+        return new LinkedFile(description, link, fileType.getName(), "");
     }
 
-    public LinkedFile(String description, URL link, String fileType, String sourceUrl) {
-        this(description, link.toString(), fileType, sourceUrl);
+    public static LinkedFile of(String description, String link, String fileType) {
+        return new LinkedFile(description, link, fileType, "");
+    }
+
+    public static LinkedFile of(URL link, String fileType) {
+        return new LinkedFile("", link.toString(), fileType, "");
+    }
+
+    public static LinkedFile of(String description, URL link, String fileType) {
+        return new LinkedFile(description, link.toString(), fileType, "");
+    }
+
+    public static LinkedFile of(String description, URL link, String fileType, String sourceUrl) {
+        return new LinkedFile(description, link.toString(), fileType, sourceUrl);
+    }
+
+    public static LinkedFile of(String description, String link, String fileType, String sourceUrl) {
+        return new LinkedFile(description, link.toString(), fileType, sourceUrl);
     }
 
     /**
      * Constructs a new LinkedFile with an empty file type and an empty description
      */
-    public LinkedFile(Path link) {
-        this("", link, "");
+    public static LinkedFile of(Path link) {
+        return LinkedFile.of("", link.toString(), "", "");
     }
 
     public StringProperty descriptionProperty() {

--- a/jablib/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/bibtex/BibEntryWriterTest.java
@@ -125,7 +125,7 @@ class BibEntryWriterTest {
     @Test
     void writeEntryWithFile() throws IOException {
         BibEntry entry = new BibEntry(StandardEntryType.Article);
-        LinkedFile file = new LinkedFile("test", Path.of("/home/uers/test.pdf"), "PDF");
+        LinkedFile file = LinkedFile.of("test", Path.of("/home/uers/test.pdf"), "PDF");
         entry.addFile(file);
 
         bibEntryWriter.write(entry, bibWriter, BibDatabaseMode.BIBTEX);

--- a/jablib/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/bibtex/FileFieldWriterTest.java
@@ -52,7 +52,7 @@ class FileFieldWriterTest {
 
     @Test
     void fileFieldWriterGetStringRepresentation() {
-        LinkedFile file = new LinkedFile("test", Path.of("X:\\Users\\abc.pdf"), "PDF");
+        LinkedFile file = LinkedFile.of("test", Path.of("X:\\Users\\abc.pdf"), "PDF");
         assertEquals("test:X\\:/Users/abc.pdf:PDF", FileFieldWriter.getStringRepresentation(file));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/cleanup/CleanupWorkerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/CleanupWorkerTest.java
@@ -88,7 +88,7 @@ class CleanupWorkerTest {
         entry.setField(StandardField.ABSTRACT, "Réflexions");
         Path path = bibFolder.resolve("ARandomlyNamedFile");
         Files.createFile(path);
-        LinkedFile fileField = new LinkedFile("", path.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", path.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
 
         List<FieldChange> changes = worker.cleanup(emptyPreset, entry);
@@ -214,11 +214,11 @@ class CleanupWorkerTest {
         Files.createDirectory(path);
         Path tempFile = Files.createFile(path.resolve("test.pdf"));
         BibEntry entry = new BibEntry();
-        LinkedFile fileField = new LinkedFile("", tempFile.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", tempFile.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
 
         worker.cleanup(preset, entry);
-        LinkedFile newFileField = new LinkedFile("", tempFile.getFileName(), "");
+        LinkedFile newFileField = LinkedFile.of("", tempFile.getFileName(), "");
         assertEquals(Optional.of(FileFieldWriter.getStringRepresentation(newFileField)), entry.getField(StandardField.FILE));
     }
 
@@ -229,11 +229,11 @@ class CleanupWorkerTest {
         Path path = pdfPath.resolve("AnotherRandomlyNamedFile");
         Files.createFile(path);
         BibEntry entry = new BibEntry();
-        LinkedFile fileField = new LinkedFile("", path.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", path.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
 
         worker.cleanup(preset, entry);
-        LinkedFile newFileField = new LinkedFile("", path.getFileName(), "");
+        LinkedFile newFileField = LinkedFile.of("", path.getFileName(), "");
         assertEquals(Optional.of(FileFieldWriter.getStringRepresentation(newFileField)), entry.getField(StandardField.FILE));
     }
 
@@ -245,11 +245,11 @@ class CleanupWorkerTest {
         Files.createFile(path);
         BibEntry entry = new BibEntry()
                 .withCitationKey("Toot");
-        LinkedFile fileField = new LinkedFile("", path.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", path.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
 
         worker.cleanup(preset, entry);
-        LinkedFile newFileField = new LinkedFile("", Path.of("Toot.tmp"), "");
+        LinkedFile newFileField = LinkedFile.of("", Path.of("Toot.tmp"), "");
         assertEquals(Optional.of(FileFieldWriter.getStringRepresentation(newFileField)), entry.getField(StandardField.FILE));
     }
 

--- a/jablib/src/test/java/org/jabref/logic/cleanup/MoveFilesCleanupTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/MoveFilesCleanupTest.java
@@ -58,7 +58,7 @@ class MoveFilesCleanupTest {
         entry.setCitationKey("Toot");
         entry.setField(StandardField.TITLE, "test title");
         entry.setField(StandardField.YEAR, "1989");
-        LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", fileBefore.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
 
         filePreferences = mock(FilePreferences.class);
@@ -73,7 +73,7 @@ class MoveFilesCleanupTest {
 
         Path fileAfter = defaultFileFolder.resolve("test.pdf");
         assertEquals(
-                Optional.of(FileFieldWriter.getStringRepresentation(new LinkedFile("", Path.of("test.pdf"), ""))),
+                Optional.of(FileFieldWriter.getStringRepresentation(LinkedFile.of("", Path.of("test.pdf"), ""))),
                 entry.getField(StandardField.FILE));
         assertFalse(Files.exists(fileBefore));
         assertTrue(Files.exists(fileAfter));
@@ -81,11 +81,11 @@ class MoveFilesCleanupTest {
 
     @Test
     void movesFileWithMulitpleLinked() {
-        LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", fileBefore.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(Arrays.asList(
-                new LinkedFile("", Path.of(""), ""),
+                LinkedFile.of("", Path.of(""), ""),
                 fileField,
-                new LinkedFile("", Path.of(""), ""))));
+                LinkedFile.of("", Path.of(""), ""))));
 
         when(filePreferences.getFileDirectoryPattern()).thenReturn("");
         cleanup.cleanup(entry);
@@ -94,9 +94,9 @@ class MoveFilesCleanupTest {
         assertEquals(
                 Optional.of(FileFieldWriter.getStringRepresentation(
                         Arrays.asList(
-                                new LinkedFile("", Path.of(""), ""),
-                                new LinkedFile("", Path.of("test.pdf"), ""),
-                                new LinkedFile("", Path.of(""), "")))),
+                                LinkedFile.of("", Path.of(""), ""),
+                                LinkedFile.of("", Path.of("test.pdf"), ""),
+                                LinkedFile.of("", Path.of(""), "")))),
                 entry.getField(StandardField.FILE));
         assertFalse(Files.exists(fileBefore));
         assertTrue(Files.exists(fileAfter));
@@ -109,7 +109,7 @@ class MoveFilesCleanupTest {
 
         Path fileAfter = defaultFileFolder.resolve("Misc").resolve("test.pdf");
         assertEquals(
-                Optional.of(FileFieldWriter.getStringRepresentation(new LinkedFile("", Path.of("Misc/test.pdf"), ""))),
+                Optional.of(FileFieldWriter.getStringRepresentation(LinkedFile.of("", Path.of("Misc/test.pdf"), ""))),
                 entry.getField(StandardField.FILE));
         assertFalse(Files.exists(fileBefore));
         assertTrue(Files.exists(fileAfter));
@@ -122,7 +122,7 @@ class MoveFilesCleanupTest {
 
         Path fileAfter = defaultFileFolder.resolve("test.pdf");
         assertEquals(
-                Optional.of(FileFieldWriter.getStringRepresentation(new LinkedFile("", Path.of("test.pdf"), ""))),
+                Optional.of(FileFieldWriter.getStringRepresentation(LinkedFile.of("", Path.of("test.pdf"), ""))),
                 entry.getField(StandardField.FILE));
         assertFalse(Files.exists(fileBefore));
         assertTrue(Files.exists(fileAfter));
@@ -135,7 +135,7 @@ class MoveFilesCleanupTest {
 
         Path fileAfter = defaultFileFolder.resolve("Misc").resolve("1989").resolve("test.pdf");
         assertEquals(
-                Optional.of(FileFieldWriter.getStringRepresentation(new LinkedFile("", Path.of("Misc/1989/test.pdf"), ""))),
+                Optional.of(FileFieldWriter.getStringRepresentation(LinkedFile.of("", Path.of("Misc/1989/test.pdf"), ""))),
                 entry.getField(StandardField.FILE));
         assertFalse(Files.exists(fileBefore));
         assertTrue(Files.exists(fileAfter));

--- a/jablib/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/RemoveLinksToNotExistentFilesTest.java
@@ -48,7 +48,7 @@ class RemoveLinksToNotExistentFilesTest {
         Files.createFile(testBibFolder);
         databaseContext.setDatabasePath(testBibFolder);
 
-        LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", fileBefore.toAbsolutePath(), "");
 
         // Entry with one online and one normal linked file
         entry = new BibEntry(StandardEntryType.Article)
@@ -57,7 +57,7 @@ class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
-                        new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
+                        LinkedFile.of("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
                         fileField)))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")
@@ -75,12 +75,12 @@ class RemoveLinksToNotExistentFilesTest {
 
     @Test
     void deleteFileInEntryWithMultipleFileLinks() throws IOException {
-        LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", fileBefore.toAbsolutePath(), "");
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
                 FileFieldWriter.getStringRepresentation(List.of(
-                        new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
+                        LinkedFile.of("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
                         fileField)),
-                FileFieldWriter.getStringRepresentation(new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"))
+                FileFieldWriter.getStringRepresentation(LinkedFile.of("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"))
         );
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.AUTHOR, "Shatakshi Sharma and Bhim Singh and Sukumar Mishra")
@@ -88,7 +88,7 @@ class RemoveLinksToNotExistentFilesTest {
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(
-                        new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF")))
+                        LinkedFile.of("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF")))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")
                 .withField(StandardField.JOURNALTITLE, "IEEE Transactions on Industrial Informatics")
@@ -107,14 +107,14 @@ class RemoveLinksToNotExistentFilesTest {
 
     @Test
     void keepLinksToExistingFiles() {
-        LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", fileBefore.toAbsolutePath(), "");
         BibEntry expectedEntry = new BibEntry(StandardEntryType.Article)
                 .withField(StandardField.AUTHOR, "Shatakshi Sharma and Bhim Singh and Sukumar Mishra")
                 .withField(StandardField.DATE, "April 2020")
                 .withField(StandardField.YEAR, "2020")
                 .withField(StandardField.DOI, "10.1109/TII.2019.2935531")
                 .withField(StandardField.FILE, FileFieldWriter.getStringRepresentation(List.of(
-                        new LinkedFile("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
+                        LinkedFile.of("", "https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8801912", "PDF"),
                         fileField)))
                 .withField(StandardField.ISSUE, "4")
                 .withField(StandardField.ISSN, "1941-0050")
@@ -133,9 +133,9 @@ class RemoveLinksToNotExistentFilesTest {
 
     @Test
     void deleteLinkedFile() throws IOException {
-        LinkedFile fileField = new LinkedFile("", fileBefore.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", fileBefore.toAbsolutePath(), "");
 
-        // There is only one linked file in entry
+        // There is only one linked file in the entry
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
         FieldChange expectedChange = new FieldChange(entry, StandardField.FILE,
                 FileFieldWriter.getStringRepresentation(fileField),

--- a/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
+++ b/jablib/src/test/java/org/jabref/logic/cleanup/RenamePdfCleanupTest.java
@@ -59,7 +59,7 @@ class RenamePdfCleanupTest {
         Path path = testFolder.resolve("toot.tmp");
         Files.createFile(path);
 
-        LinkedFile fileField = new LinkedFile("", path.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", path.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
 
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey]");
@@ -82,18 +82,18 @@ class RenamePdfCleanupTest {
         entry.setField(StandardField.TITLE, "test title");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(
                 Arrays.asList(
-                        new LinkedFile("", Path.of(""), ""),
-                        new LinkedFile("", path.toAbsolutePath(), ""),
-                        new LinkedFile("", Path.of(""), ""))));
+                        LinkedFile.of("", Path.of(""), ""),
+                        LinkedFile.of("", path.toAbsolutePath(), ""),
+                        LinkedFile.of("", Path.of(""), ""))));
 
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey] - [fulltitle]");
         cleanup.cleanup(entry);
 
         assertEquals(Optional.of(FileFieldWriter.getStringRepresentation(
                         Arrays.asList(
-                                new LinkedFile("", Path.of(""), ""),
-                                new LinkedFile("", Path.of("Toot - test title.tmp"), ""),
-                                new LinkedFile("", Path.of(""), "")))),
+                                LinkedFile.of("", Path.of(""), ""),
+                                LinkedFile.of("", Path.of("Toot - test title.tmp"), ""),
+                                LinkedFile.of("", Path.of(""), "")))),
                 entry.getField(StandardField.FILE));
     }
 
@@ -102,14 +102,14 @@ class RenamePdfCleanupTest {
         Path path = testFolder.resolve("Toot.tmp");
         Files.createFile(path);
 
-        LinkedFile fileField = new LinkedFile("", path.toAbsolutePath(), "");
+        LinkedFile fileField = LinkedFile.of("", path.toAbsolutePath(), "");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
         entry.setField(StandardField.TITLE, "test title");
 
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey] - [fulltitle]");
         cleanup.cleanup(entry);
 
-        LinkedFile newFileField = new LinkedFile("", Path.of("Toot - test title.tmp"), "");
+        LinkedFile newFileField = LinkedFile.of("", Path.of("Toot - test title.tmp"), "");
         assertEquals(Optional.of(FileFieldWriter.getStringRepresentation(newFileField)), entry.getField(StandardField.FILE));
     }
 
@@ -117,14 +117,14 @@ class RenamePdfCleanupTest {
     void cleanupRenamePdfRenamesFileInSameFolder() throws IOException {
         Path path = testFolder.resolve("Toot.pdf");
         Files.createFile(path);
-        LinkedFile fileField = new LinkedFile("", Path.of("Toot.pdf"), "PDF");
+        LinkedFile fileField = LinkedFile.of("", Path.of("Toot.pdf"), "PDF");
         entry.setField(StandardField.FILE, FileFieldWriter.getStringRepresentation(fileField));
         entry.setField(StandardField.TITLE, "test title");
 
         when(filePreferences.getFileNamePattern()).thenReturn("[citationkey] - [fulltitle]");
         cleanup.cleanup(entry);
 
-        LinkedFile newFileField = new LinkedFile("", Path.of("Toot - test title.pdf"), "PDF");
+        LinkedFile newFileField = LinkedFile.of("", Path.of("Toot - test title.pdf"), "PDF");
         assertEquals(Optional.of(FileFieldWriter.getStringRepresentation(newFileField)), entry.getField(StandardField.FILE));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/EmbeddedBibFilePdfExporterTest.java
@@ -89,7 +89,7 @@ class EmbeddedBibFilePdfExporterTest {
         toral2006.setField(StandardField.OWNER, "Ich");
         toral2006.setField(StandardField.URL, "www.url.de");
 
-        toral2006.setFiles(List.of(new LinkedFile("non-existing", "path/to/nowhere.pdf", "PDF")));
+        toral2006.setFiles(List.of(LinkedFile.of("non-existing", "path/to/nowhere.pdf", "PDF")));
 
         vapnik2000.setCitationKey("vapnik2000");
         vapnik2000.setField(StandardField.TITLE, "The Nature of Statistical Learning Theory");
@@ -187,7 +187,7 @@ class EmbeddedBibFilePdfExporterTest {
             pdf.save(pdfFile.toAbsolutePath().toString());
         }
 
-        return new LinkedFile("A linked pdf", pdfFile, "PDF");
+        return LinkedFile.of("A linked pdf", pdfFile, "PDF");
     }
 
     @ParameterizedTest

--- a/jablib/src/test/java/org/jabref/logic/exporter/XmpPdfExporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/exporter/XmpPdfExporterTest.java
@@ -89,7 +89,7 @@ class XmpPdfExporterTest {
                   .withField(StandardField.EPRINTTYPE, "asdf")
                   .withField(StandardField.OWNER, "Ich")
                   .withField(StandardField.URL, "www.url.de")
-                  .withFiles(List.of(new LinkedFile("non-existing", "path/to/nowhere.pdf", "PDF")));
+                  .withFiles(List.of(LinkedFile.of("non-existing", "path/to/nowhere.pdf", "PDF")));
 
         VAPNIK_2000.withCitationKey("vapnik2000")
                    .withField(StandardField.TITLE, "The Nature of Statistical Learning Theory")
@@ -132,7 +132,7 @@ class XmpPdfExporterTest {
         }
         LinkedFile linkedFile = createDefaultLinkedFile("existing.pdf", tempDir);
         OLLY_2018.setFiles(List.of(linkedFile));
-        TORAL_2006.setFiles(List.of(new LinkedFile("non-existing", "path/to/nowhere.pdf", "PDF")));
+        TORAL_2006.setFiles(List.of(LinkedFile.of("non-existing", "path/to/nowhere.pdf", "PDF")));
     }
 
     @ParameterizedTest
@@ -215,7 +215,7 @@ class XmpPdfExporterTest {
             pdf.save(pdfFile.toAbsolutePath().toString());
         }
 
-        return new LinkedFile("", pdfFile, "PDF");
+        return LinkedFile.of("", pdfFile, "PDF");
     }
 }
 

--- a/jablib/src/test/java/org/jabref/logic/externalfiles/LinkedFileHandlerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/externalfiles/LinkedFileHandlerTest.java
@@ -51,7 +51,7 @@ class LinkedFileHandlerTest {
         final Path tempFile = tempFolder.resolve(originalFileName);
         Files.createFile(tempFile);
 
-        final LinkedFile linkedFile = new LinkedFile("", tempFile, "");
+        final LinkedFile linkedFile = LinkedFile.of("", tempFile, "");
         LinkedFileHandler linkedFileHandler = new LinkedFileHandler(linkedFile, entry, databaseContext, filePreferences);
 
         linkedFileHandler.renameToName(newFileName, false);

--- a/jablib/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fetcher/BvbFetcherTest.java
@@ -31,7 +31,7 @@ class BvbFetcherTest {
             .withField(StandardField.AUTHOR, "Bloch, Joshua")
             .withField(StandardField.TITLEADDON, "Joshua Bloch")
             .withField(StandardField.EDITION, "3. Auflage, Übersetzung der englischsprachigen 3. Originalausgabe 2018")
-            .withFiles(List.of(new LinkedFile("", "http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=1906353", StandardFileType.PDF)))
+            .withFiles(List.of(LinkedFile.of("", "http://search.ebscohost.com/login.aspx?direct=true&scope=site&db=nlebk&db=nlabk&AN=1906353", StandardFileType.PDF)))
             .withField(StandardField.ISBN, "9783960886402")
             .withField(StandardField.KEYWORDS, "Klassen, Interfaces, Generics, Enums, Annotationen, Lambdas, Streams, Module, parallel, Parallele Programmierung, Serialisierung, funktional, funktionale Programmierung, Java EE, Jakarta EE")
             .withField(StandardField.ADDRESS, "Heidelberg")

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/BibtexParserTest.java
@@ -2243,7 +2243,7 @@ class BibtexParserTest {
                 .withCitationKey("Test2017");
         BibEntry secondEntry = new BibEntry(StandardEntryType.Article)
                 .withCitationKey("Test2")
-                .withFiles(List.of(new LinkedFile("", "../../../Papers/Asheim2005 The Geography of Innovation Regional Innovation Systems.pdf", "")));
+                .withFiles(List.of(LinkedFile.of("", "../../../Papers/Asheim2005 The Geography of Innovation Regional Innovation Systems.pdf", "")));
 
         assertEquals(List.of(firstEntry, secondEntry), result.getDatabase().getEntries());
     }

--- a/jablib/src/test/java/org/jabref/logic/importer/fileformat/pdf/PdfMergeMetadataImporterTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/fileformat/pdf/PdfMergeMetadataImporterTest.java
@@ -87,7 +87,7 @@ class PdfMergeMetadataImporterTest {
         expected.setField(StandardField.VOLUME, "1");
 
         // From merge
-        expected.setFiles(List.of(new LinkedFile("", file.toAbsolutePath(), StandardFileType.PDF.getName())));
+        expected.setFiles(List.of(LinkedFile.of("", file.toAbsolutePath(), StandardFileType.PDF.getName())));
 
         assertEquals(List.of(expected), result);
     }

--- a/jablib/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
+++ b/jablib/src/test/java/org/jabref/logic/importer/util/FileFieldParserTest.java
@@ -20,11 +20,11 @@ class FileFieldParserTest {
     private static Stream<Arguments> testData() {
         return Stream.of(
                 Arguments.of(
-                        new LinkedFile("arXiv Fulltext PDF", "https://arxiv.org/pdf/1109.0517.pdf", "application/pdf"),
+                        LinkedFile.of("arXiv Fulltext PDF", "https://arxiv.org/pdf/1109.0517.pdf", "application/pdf"),
                         List.of("arXiv Fulltext PDF", "https://arxiv.org/pdf/1109.0517.pdf", "application/pdf")
                 ),
                 Arguments.of(
-                        new LinkedFile("arXiv Fulltext PDF", "https/://arxiv.org/pdf/1109.0517.pdf", "application/pdf"),
+                        LinkedFile.of("arXiv Fulltext PDF", "https/://arxiv.org/pdf/1109.0517.pdf", "application/pdf"),
                         List.of("arXiv Fulltext PDF", "https\\://arxiv.org/pdf/1109.0517.pdf", "application/pdf")
                 )
         );
@@ -53,171 +53,171 @@ class FileFieldParserTest {
 
                 // URL starting with www. (without protocol)
                 Arguments.of(
-                        List.of(new LinkedFile("A test", URLUtil.create("https://www.yahoo.com/abc/cde.htm"), "URL")),
+                        List.of(LinkedFile.of("A test", URLUtil.create("https://www.yahoo.com/abc/cde.htm"), "URL")),
                         "A test:www.yahoo.com/abc/cde.htm:URL"
                 ),
 
                 // correct input
                 Arguments.of(
-                        List.of(new LinkedFile("Desc", Path.of("File.PDF"), "PDF")),
+                        List.of(LinkedFile.of("Desc", Path.of("File.PDF"), "PDF")),
                         "Desc:File.PDF:PDF"
                 ),
 
                 // Mendeley input
                 Arguments.of(
-                        List.of(new LinkedFile("", Path.of("C:/Users/XXXXXX/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Brown - 2017 - Physical test methods for elastomers.pdf"), "pdf")),
+                        List.of(LinkedFile.of("", Path.of("C:/Users/XXXXXX/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Brown - 2017 - Physical test methods for elastomers.pdf"), "pdf")),
                         ":C$\\backslash$:/Users/XXXXXX/AppData/Local/Mendeley Ltd./Mendeley Desktop/Downloaded/Brown - 2017 - Physical test methods for elastomers.pdf:pdf"
                 ),
 
                 // parseCorrectOnlineInput
                 Arguments.of(
-                        List.of(new LinkedFile(URLUtil.create("http://arxiv.org/pdf/2010.08497v1"), "PDF")),
+                        List.of(LinkedFile.of(URLUtil.create("http://arxiv.org/pdf/2010.08497v1"), "PDF")),
                         ":http\\://arxiv.org/pdf/2010.08497v1:PDF"
                 ),
 
                 // parseFaultyOnlineInput
                 Arguments.of(
-                        List.of(new LinkedFile("", "htt://arxiv.org/pdf/2010.08497v1", "PDF")),
+                        List.of(LinkedFile.of("", "htt://arxiv.org/pdf/2010.08497v1", "PDF")),
                         ":htt\\://arxiv.org/pdf/2010.08497v1:PDF"
                 ),
 
                 // parseFaultyArxivOnlineInput
                 Arguments.of(
-                        List.of(new LinkedFile("arXiv Fulltext PDF", "https://arxiv.org/pdf/1109.0517.pdf", "application/pdf")),
+                        List.of(LinkedFile.of("arXiv Fulltext PDF", "https://arxiv.org/pdf/1109.0517.pdf", "application/pdf")),
                         "arXiv Fulltext PDF:https\\://arxiv.org/pdf/1109.0517.pdf:application/pdf"
                 ),
 
                 // ignoreMissingDescription
                 Arguments.of(
-                        List.of(new LinkedFile("", Path.of("wei2005ahp.pdf"), "PDF")),
+                        List.of(LinkedFile.of("", Path.of("wei2005ahp.pdf"), "PDF")),
                         ":wei2005ahp.pdf:PDF"
                 ),
 
                 // interpretLinkAsOnlyMandatoryField: single
                 Arguments.of(
-                        List.of(new LinkedFile("", Path.of("wei2005ahp.pdf"), "")),
+                        List.of(LinkedFile.of("", Path.of("wei2005ahp.pdf"), "")),
                         "wei2005ahp.pdf"
                 ),
 
                 // interpretLinkAsOnlyMandatoryField: multiple
                 Arguments.of(
                         List.of(
-                                new LinkedFile("", Path.of("wei2005ahp.pdf"), ""),
-                                new LinkedFile("", Path.of("other.pdf"), "")
+                                LinkedFile.of("", Path.of("wei2005ahp.pdf"), ""),
+                                LinkedFile.of("", Path.of("other.pdf"), "")
                         ),
                         "wei2005ahp.pdf;other.pdf"
                 ),
 
                 // escapedCharactersInDescription
                 Arguments.of(
-                        List.of(new LinkedFile("test:;", Path.of("wei2005ahp.pdf"), "PDF")),
+                        List.of(LinkedFile.of("test:;", Path.of("wei2005ahp.pdf"), "PDF")),
                         "test\\:\\;:wei2005ahp.pdf:PDF"
                 ),
 
                 // handleXmlCharacters
                 Arguments.of(
-                        List.of(new LinkedFile("test&#44;st:;", Path.of("wei2005ahp.pdf"), "PDF")),
+                        List.of(LinkedFile.of("test&#44;st:;", Path.of("wei2005ahp.pdf"), "PDF")),
                         "test&#44\\;st\\:\\;:wei2005ahp.pdf:PDF"
                 ),
 
                 // handleEscapedFilePath
                 Arguments.of(
-                        List.of(new LinkedFile("desc", Path.of("C:\\test.pdf"), "PDF")),
+                        List.of(LinkedFile.of("desc", Path.of("C:\\test.pdf"), "PDF")),
                         "desc:C\\:\\\\test.pdf:PDF"
                 ),
 
                 // handleNonEscapedFilePath
                 Arguments.of(
-                        List.of(new LinkedFile("desc", Path.of("C:\\test.pdf"), "PDF")),
+                        List.of(LinkedFile.of("desc", Path.of("C:\\test.pdf"), "PDF")),
                         "desc:C:\\test.pdf:PDF"
                 ),
 
                 // Source: https://github.com/JabRef/jabref/issues/8991#issuecomment-1214131042
                 Arguments.of(
-                        List.of(new LinkedFile("Boyd2012.pdf", Path.of("C:\\Users\\Literature_database\\Boyd2012.pdf"), "PDF")),
+                        List.of(LinkedFile.of("Boyd2012.pdf", Path.of("C:\\Users\\Literature_database\\Boyd2012.pdf"), "PDF")),
                         "Boyd2012.pdf:C\\:\\\\Users\\\\Literature_database\\\\Boyd2012.pdf:PDF"
                 ),
 
                 // subsetOfFieldsResultsInFileLink: description only
                 Arguments.of(
-                        List.of(new LinkedFile("", Path.of("file.pdf"), "")),
+                        List.of(LinkedFile.of("", Path.of("file.pdf"), "")),
                         "file.pdf::"
                 ),
 
                 // subsetOfFieldsResultsInFileLink: file only
                 Arguments.of(
-                        List.of(new LinkedFile("", Path.of("file.pdf"), "")),
+                        List.of(LinkedFile.of("", Path.of("file.pdf"), "")),
                         ":file.pdf"
                 ),
 
                 // subsetOfFieldsResultsInFileLink: type only
                 Arguments.of(
-                        List.of(new LinkedFile("", Path.of("file.pdf"), "")),
+                        List.of(LinkedFile.of("", Path.of("file.pdf"), "")),
                         "::file.pdf"
                 ),
 
                 // tooManySeparators
                 Arguments.of(
-                        List.of(new LinkedFile("desc", Path.of("file.pdf"), "PDF", "qwer")),
+                        List.of(LinkedFile.of("desc", Path.of("file.pdf"), "PDF", "qwer")),
                         "desc:file.pdf:PDF:qwer:asdf:uiop"
                 ),
 
                 // www inside filename
                 Arguments.of(
-                        List.of(new LinkedFile("", Path.of("/home/www.google.de.pdf"), "")),
+                        List.of(LinkedFile.of("", Path.of("/home/www.google.de.pdf"), "")),
                         ":/home/www.google.de.pdf"
                 ),
 
                 // url
                 Arguments.of(
-                        List.of(new LinkedFile(URLUtil.create("https://books.google.de/"), "")),
+                        List.of(LinkedFile.of(URLUtil.create("https://books.google.de/"), "")),
                         "https://books.google.de/"
                 ),
 
                 // url with www
                 Arguments.of(
-                        List.of(new LinkedFile(URLUtil.create("https://www.google.de/"), "")),
+                        List.of(LinkedFile.of(URLUtil.create("https://www.google.de/"), "")),
                         "https://www.google.de/"
                 ),
 
                 // url as file
                 Arguments.of(
-                        List.of(new LinkedFile("", URLUtil.create("http://ceur-ws.org/Vol-438"), "URL")),
+                        List.of(LinkedFile.of("", URLUtil.create("http://ceur-ws.org/Vol-438"), "URL")),
                         ":http\\://ceur-ws.org/Vol-438:URL"
                 ),
                 // url as file with desc
                 Arguments.of(
-                        List.of(new LinkedFile("desc", URLUtil.create("http://ceur-ws.org/Vol-438"), "URL")),
+                        List.of(LinkedFile.of("desc", URLUtil.create("http://ceur-ws.org/Vol-438"), "URL")),
                         "desc:http\\://ceur-ws.org/Vol-438:URL"
                 ),
                 // link with source url
                 Arguments.of(
-                        List.of(new LinkedFile("arXiv Fulltext PDF", "matheus.ea explicit.pdf", "PDF", "https://arxiv.org/pdf/1109.0517.pdf")),
+                        List.of(LinkedFile.of("arXiv Fulltext PDF", "matheus.ea explicit.pdf", "PDF", "https://arxiv.org/pdf/1109.0517.pdf")),
                         "arXiv Fulltext PDF:matheus.ea explicit.pdf:PDF:https\\://arxiv.org/pdf/1109.0517.pdf"
                 ),
                 // link without description and with source url
                 Arguments.of(
-                        List.of(new LinkedFile("", "matheus.ea explicit.pdf", "PDF", "https://arxiv.org/pdf/1109.0517.pdf")),
+                        List.of(LinkedFile.of("", "matheus.ea explicit.pdf", "PDF", "https://arxiv.org/pdf/1109.0517.pdf")),
                         ":matheus.ea explicit.pdf:PDF:https\\://arxiv.org/pdf/1109.0517.pdf"
                 ),
                 // no link but with source url
                 Arguments.of(
-                        List.of(new LinkedFile("arXiv Fulltext PDF", "", "PDF", "https://arxiv.org/pdf/1109.0517.pdf")),
+                        List.of(LinkedFile.of("arXiv Fulltext PDF", "", "PDF", "https://arxiv.org/pdf/1109.0517.pdf")),
                         "arXiv Fulltext PDF::PDF:https\\://arxiv.org/pdf/1109.0517.pdf"
                 ),
                 // No description or file type but with sourceURL
                 Arguments.of(
-                        List.of(new LinkedFile("", "matheus.ea explicit.pdf", "", "https://arxiv.org/pdf/1109.0517.pdf")),
+                        List.of(LinkedFile.of("", "matheus.ea explicit.pdf", "", "https://arxiv.org/pdf/1109.0517.pdf")),
                         ":matheus.ea explicit.pdf::https\\://arxiv.org/pdf/1109.0517.pdf"
                 ),
                 // Absolute path
                 Arguments.of(
-                        List.of(new LinkedFile("", "A:\\Zotero\\storage\\test.pdf", "")),
+                        List.of(LinkedFile.of("", "A:\\Zotero\\storage\\test.pdf", "")),
                         ":A:\\Zotero\\storage\\test.pdf"
                 ),
                 // zotero absolute path
                 Arguments.of(
-                        List.of(new LinkedFile("", "A:\\Zotero\\storage\\test.pdf", "")),
+                        List.of(LinkedFile.of("", "A:\\Zotero\\storage\\test.pdf", "")),
                         "A:\\Zotero\\storage\\test.pdf"
                 )
         );

--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutTest.java
@@ -141,7 +141,7 @@ class LayoutTest {
     @Test
     void wrapFileLinksExpandFile() throws IOException {
         BibEntry entry = new BibEntry(StandardEntryType.Article);
-        entry.addFile(new LinkedFile("Test file", Path.of("encrypted.pdf"), "PDF"));
+        entry.addFile(LinkedFile.of("Test file", Path.of("encrypted.pdf"), "PDF"));
 
         String layoutText = layout(
                 "\\begin{file}\\format[WrapFileLinks(\\i. \\d (\\p))]{\\file}\\end{file}",

--- a/jablib/src/test/java/org/jabref/logic/search/DatabaseSearcherWithBibFilesTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/DatabaseSearcherWithBibFilesTest.java
@@ -57,22 +57,22 @@ class DatabaseSearcherWithBibFilesTest {
 
     private static final BibEntry MINIMAL_SENTENCE_CASE = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("minimal-sentence-case")
-            .withFiles(List.of(new LinkedFile("", "minimal-sentence-case.pdf", StandardFileType.PDF.getName())));
+            .withFiles(List.of(LinkedFile.of("", "minimal-sentence-case.pdf", StandardFileType.PDF.getName())));
     private static final BibEntry MINIMAL_ALL_UPPER_CASE = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("minimal-all-upper-case")
-            .withFiles(List.of(new LinkedFile("", "minimal-all-upper-case.pdf", StandardFileType.PDF.getName())));
+            .withFiles(List.of(LinkedFile.of("", "minimal-all-upper-case.pdf", StandardFileType.PDF.getName())));
     private static final BibEntry MINIMAL_MIXED_CASE = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("minimal-mixed-case")
-            .withFiles(List.of(new LinkedFile("", "minimal-mixed-case.pdf", StandardFileType.PDF.getName())));
+            .withFiles(List.of(LinkedFile.of("", "minimal-mixed-case.pdf", StandardFileType.PDF.getName())));
     private static final BibEntry MINIMAL_NOTE_SENTENCE_CASE = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("minimal-note-sentence-case")
-            .withFiles(List.of(new LinkedFile("", "minimal-note-sentence-case.pdf", StandardFileType.PDF.getName())));
+            .withFiles(List.of(LinkedFile.of("", "minimal-note-sentence-case.pdf", StandardFileType.PDF.getName())));
     private static final BibEntry MINIMAL_NOTE_ALL_UPPER_CASE = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("minimal-note-all-upper-case")
-            .withFiles(List.of(new LinkedFile("", "minimal-note-all-upper-case.pdf", StandardFileType.PDF.getName())));
+            .withFiles(List.of(LinkedFile.of("", "minimal-note-all-upper-case.pdf", StandardFileType.PDF.getName())));
     private static final BibEntry MINIMAL_NOTE_MIXED_CASE = new BibEntry(StandardEntryType.Misc)
             .withCitationKey("minimal-note-mixed-case")
-            .withFiles(List.of(new LinkedFile("", "minimal-note-mixed-case.pdf", StandardFileType.PDF.getName())));
+            .withFiles(List.of(LinkedFile.of("", "minimal-note-mixed-case.pdf", StandardFileType.PDF.getName())));
 
     private final CliPreferences preferences = mock(CliPreferences.class);
     private final FilePreferences filePreferences = mock(FilePreferences.class);

--- a/jablib/src/test/java/org/jabref/logic/search/indexing/LinkedFilesIndexerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/search/indexing/LinkedFilesIndexerTest.java
@@ -54,7 +54,7 @@ public class LinkedFilesIndexerTest {
     void exampleThesisIndex() throws IOException {
         // given
         BibEntry entry = new BibEntry(StandardEntryType.PhdThesis)
-                .withFiles(List.of(new LinkedFile("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
+                .withFiles(List.of(LinkedFile.of("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
 
         // when
         indexer.addToIndex(List.of(entry), mock(BackgroundTask.class));
@@ -70,7 +70,7 @@ public class LinkedFilesIndexerTest {
     void dontIndexNonPdf() throws IOException {
         // given
         BibEntry entry = new BibEntry(StandardEntryType.PhdThesis)
-                .withFiles(List.of(new LinkedFile("Example Thesis", "thesis-example.pdf", StandardFileType.AUX.getName())));
+                .withFiles(List.of(LinkedFile.of("Example Thesis", "thesis-example.pdf", StandardFileType.AUX.getName())));
 
         // when
         indexer.addToIndex(List.of(entry), mock(BackgroundTask.class));
@@ -86,7 +86,7 @@ public class LinkedFilesIndexerTest {
     void dontIndexOnlineLinks() throws IOException {
         // given
         BibEntry entry = new BibEntry(StandardEntryType.PhdThesis)
-                .withFiles(List.of(new LinkedFile("Example Thesis", "https://raw.githubusercontent.com/JabRef/jabref/main/src/test/resources/pdfs/thesis-example.pdf", StandardFileType.PDF.getName())));
+                .withFiles(List.of(LinkedFile.of("Example Thesis", "https://raw.githubusercontent.com/JabRef/jabref/main/src/test/resources/pdfs/thesis-example.pdf", StandardFileType.PDF.getName())));
 
         // when
         indexer.addToIndex(List.of(entry), mock(BackgroundTask.class));
@@ -103,7 +103,7 @@ public class LinkedFilesIndexerTest {
         // given
         BibEntry entry = new BibEntry(StandardEntryType.PhdThesis)
                 .withCitationKey("Example2017")
-                .withFiles(List.of(new LinkedFile("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
+                .withFiles(List.of(LinkedFile.of("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
 
         // when
         indexer.addToIndex(List.of(entry), mock(BackgroundTask.class));
@@ -119,7 +119,7 @@ public class LinkedFilesIndexerTest {
     void metaDataIndex() throws IOException {
         // given
         BibEntry entry = new BibEntry(StandardEntryType.Article)
-                .withFiles(List.of(new LinkedFile("Example Thesis", "metaData.pdf", StandardFileType.PDF.getName())));
+                .withFiles(List.of(LinkedFile.of("Example Thesis", "metaData.pdf", StandardFileType.PDF.getName())));
 
         // when
         indexer.addToIndex(List.of(entry), mock(BackgroundTask.class));
@@ -136,7 +136,7 @@ public class LinkedFilesIndexerTest {
         // given
         BibEntry exampleThesis = new BibEntry(StandardEntryType.PhdThesis)
                 .withCitationKey("ExampleThesis2017")
-                .withFiles(List.of(new LinkedFile("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
+                .withFiles(List.of(LinkedFile.of("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
 
         // when
         indexer.addToIndex(List.of(exampleThesis), mock(BackgroundTask.class));
@@ -149,7 +149,7 @@ public class LinkedFilesIndexerTest {
 
         BibEntry metadata = new BibEntry(StandardEntryType.Article)
                 .withCitationKey("MetaData2017")
-                .withFiles(List.of(new LinkedFile("Metadata file", "metaData.pdf", StandardFileType.PDF.getName())));
+                .withFiles(List.of(LinkedFile.of("Metadata file", "metaData.pdf", StandardFileType.PDF.getName())));
 
         // when
         indexer.addToIndex(List.of(metadata), mock(BackgroundTask.class));
@@ -166,7 +166,7 @@ public class LinkedFilesIndexerTest {
         // given
         BibEntry entry = new BibEntry(StandardEntryType.PhdThesis)
                 .withCitationKey("Example2017")
-                .withFiles(List.of(new LinkedFile("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
+                .withFiles(List.of(LinkedFile.of("Example Thesis", "thesis-example.pdf", StandardFileType.PDF.getName())));
 
         indexer.addToIndex(List.of(entry), mock(BackgroundTask.class));
 

--- a/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
+++ b/jablib/src/test/java/org/jabref/logic/util/io/FileUtilTest.java
@@ -562,12 +562,12 @@ class FileUtilTest {
         when(fileDirPrefs.shouldStoreFilesRelativeToBibFile()).thenReturn(true);
 
         Path testPdf = filesPath.resolve("test.pdf");
-        BibEntry source1 = new BibEntry().withFiles(List.of(new LinkedFile(testPdf)));
-        BibEntry target1 = new BibEntry().withFiles(List.of(new LinkedFile(filesPath.relativize(testPdf))));
+        BibEntry source1 = new BibEntry().withFiles(List.of(LinkedFile.of(testPdf)));
+        BibEntry target1 = new BibEntry().withFiles(List.of(LinkedFile.of(filesPath.relativize(testPdf))));
 
         testPdf = bibPath.resolve("test.pdf");
-        BibEntry source2 = new BibEntry().withFiles(List.of(new LinkedFile(testPdf)));
-        BibEntry target2 = new BibEntry().withFiles(List.of(new LinkedFile(bibTempDir.relativize(testPdf))));
+        BibEntry source2 = new BibEntry().withFiles(List.of(LinkedFile.of(testPdf)));
+        BibEntry target2 = new BibEntry().withFiles(List.of(LinkedFile.of(bibTempDir.relativize(testPdf))));
 
         return Stream.of(
                 Arguments.of(List.of(target1), List.of(source1), database, fileDirPrefs),

--- a/jablib/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
+++ b/jablib/src/test/java/org/jabref/logic/xmp/XmpUtilReaderTest.java
@@ -65,8 +65,8 @@ class XmpUtilReaderTest {
         Path bibFile = Path.of(XmpUtilShared.class.getResource("article_dublinCore.bib").toURI());
         List<BibEntry> expected = bibtexImporter.importDatabase(bibFile).getDatabase().getEntries();
         expected.forEach(bibEntry -> bibEntry.setFiles(Arrays.asList(
-                new LinkedFile("", Path.of("paper.pdf"), "PDF"),
-                new LinkedFile("", pathPdf.toAbsolutePath(), "PDF"))
+                LinkedFile.of("", Path.of("paper.pdf"), "PDF"),
+                LinkedFile.of("", pathPdf.toAbsolutePath(), "PDF"))
         ));
 
         assertEquals(expected, entries);
@@ -80,7 +80,7 @@ class XmpUtilReaderTest {
         Path bibFile = Path.of(XmpUtilShared.class.getResource("article_dublinCore_partial_date.bib").toURI());
         List<BibEntry> expected = bibtexImporter.importDatabase(bibFile).getDatabase().getEntries();
         expected.forEach(bibEntry -> bibEntry.setFiles(List.of(
-                new LinkedFile("", pathPdf.toAbsolutePath(), "PDF"))
+                LinkedFile.of("", pathPdf.toAbsolutePath(), "PDF"))
         ));
 
         assertEquals(expected, entries);
@@ -104,7 +104,7 @@ class XmpUtilReaderTest {
         List<BibEntry> expected = bibtexImporter.importDatabase(bibFile).getDatabase().getEntries();
 
         expected.forEach(bibEntry -> bibEntry.setFiles(List.of(
-                new LinkedFile("", pathPdf.toAbsolutePath(), "PDF"))
+                LinkedFile.of("", pathPdf.toAbsolutePath(), "PDF"))
         ));
 
         assertEquals(expected, entries);

--- a/jablib/src/test/java/org/jabref/model/entry/BibEntryTest.java
+++ b/jablib/src/test/java/org/jabref/model/entry/BibEntryTest.java
@@ -246,19 +246,19 @@ class BibEntryTest {
     @Test
     void getAndAddToLinkedFileList() {
         List<LinkedFile> files = entry.getFiles();
-        files.add(new LinkedFile("", Path.of(""), ""));
+        files.add(LinkedFile.of("", Path.of(""), ""));
         entry.setFiles(files);
-        assertEquals(List.of(new LinkedFile("", Path.of(""), "")), entry.getFiles());
+        assertEquals(List.of(LinkedFile.of("", Path.of(""), "")), entry.getFiles());
     }
 
     @Test
     void replaceOfLinkWorks() throws MalformedURLException {
         List<LinkedFile> files = new ArrayList<>();
         String urlAsString = "https://www.example.org/file.pdf";
-        files.add(new LinkedFile(URLUtil.create(urlAsString), ""));
+        files.add(LinkedFile.of(URLUtil.create(urlAsString), ""));
         entry.setFiles(files);
 
-        LinkedFile linkedFile = new LinkedFile("", Path.of("file.pdf", ""), "");
+        LinkedFile linkedFile = LinkedFile.of("", Path.of("file.pdf", ""), "");
         entry.replaceDownloadedFile(urlAsString, linkedFile);
         assertEquals(List.of(linkedFile), entry.getFiles());
     }


### PR DESCRIPTION
Closes https://github.com/JabRef/jabref/issues/14066

Refactored AutoCompletionTextInputBinding and BibDatabaseContext to use the Builder pattern, replaced LinkedFile constructors with static factory methods, and updated usages on LinkedFile to address issue #14066.

### Steps to test

1. Check out this branch and build the project using `./gradlew build`
2. Ensure the build completes successfully without errors

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (if applicable)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
