### PR TITLE
Parameterize tests (issue #676)

### DIFF
--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -95,7 +95,7 @@ class LayoutEntryTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            bla, foo, test, fark, 'bla(test),foo(fark)'
+            bla, foo, test, fark, 'bla("test"),foo("fark")'
             bla, foo, test, fark, 'bla(test),foo(fark)'
             """)
     void parseTwoMethodsWithArguments(String expectedName1, String expectedName2,

--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -75,9 +75,9 @@ class LayoutEntryTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            bla , bla
-            bla , bla
-            _bla.bla.blub , _bla.bla.blub
+            bla, bla
+            bla, bla
+            _bla.bla.blub, _bla.bla.blub
             """)
     void parseSingleMethodWithoutArguments(String expected, String input) {
         assertEquals(1, LayoutEntry.parseMethodsCalls(input).size());
@@ -95,8 +95,8 @@ class LayoutEntryTest {
 
     @ParameterizedTest
     @CsvSource(delimiterString = ";", textBlock = """
-            bla ; foo ; test ; fark ; 'bla("test"),foo("fark")'
-            bla ; foo ; test ; fark ; 'bla(test),foo(fark)'
+            bla; foo; test; fark; 'bla("test"),foo("fark")'
+            bla; foo; test; fark; 'bla(test),foo(fark)'
             """)
     void parseTwoMethodsWithArguments(String expectedName1, String expectedName2,
                                       String expectedArg1, String expectedArg2, String input) {

--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -73,32 +73,38 @@ class LayoutEntryTest {
         return layout.doLayout(entry, null);
     }
 
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            bla -> bla
+            bla -> bla,
+            _bla.bla.blub -> _bla.bla.blub,
+            """)
+    void parseSingleMethodWithoutArguments(String expected, String input) {
+        assertEquals(1, LayoutEntry.parseMethodsCalls(input).size());
+        assertEquals(expected, LayoutEntry.parseMethodsCalls(input).getFirst().getFirst());
+    }
+
     @Test
-    void parseMethodCalls() {
-        assertEquals(1, LayoutEntry.parseMethodsCalls("bla").size());
-        assertEquals("bla", LayoutEntry.parseMethodsCalls("bla").getFirst().getFirst());
+    void parseTwoMethodsWithoutArguments() {
+        String input = "bla,foo";
+        var result = LayoutEntry.parseMethodsCalls(input);
+        assertEquals(2, result.size());
+        assertEquals("bla", result.getFirst().getFirst());
+        assertEquals("foo", result.get(1).getFirst());
+    }
 
-        assertEquals(1, LayoutEntry.parseMethodsCalls("bla,").size());
-        assertEquals("bla", LayoutEntry.parseMethodsCalls("bla,").getFirst().getFirst());
-
-        assertEquals(1, LayoutEntry.parseMethodsCalls("_bla.bla.blub,").size());
-        assertEquals("_bla.bla.blub", LayoutEntry.parseMethodsCalls("_bla.bla.blub,").getFirst().getFirst());
-
-        assertEquals(2, LayoutEntry.parseMethodsCalls("bla,foo").size());
-        assertEquals("bla", LayoutEntry.parseMethodsCalls("bla,foo").getFirst().getFirst());
-        assertEquals("foo", LayoutEntry.parseMethodsCalls("bla,foo").get(1).getFirst());
-
-        assertEquals(2, LayoutEntry.parseMethodsCalls("bla(\"test\"),foo(\"fark\")").size());
-        assertEquals("bla", LayoutEntry.parseMethodsCalls("bla(\"test\"),foo(\"fark\")").getFirst().getFirst());
-        assertEquals("foo", LayoutEntry.parseMethodsCalls("bla(\"test\"),foo(\"fark\")").get(1).getFirst());
-        assertEquals("test", LayoutEntry.parseMethodsCalls("bla(\"test\"),foo(\"fark\")").getFirst().get(1));
-        assertEquals("fark", LayoutEntry.parseMethodsCalls("bla(\"test\"),foo(\"fark\")").get(1).get(1));
-
-        assertEquals(2, LayoutEntry.parseMethodsCalls("bla(test),foo(fark)").size());
-        assertEquals("bla", LayoutEntry.parseMethodsCalls("bla(test),foo(fark)").getFirst().getFirst());
-        assertEquals("foo", LayoutEntry.parseMethodsCalls("bla(test),foo(fark)").get(1).getFirst());
-        assertEquals("test", LayoutEntry.parseMethodsCalls("bla(test),foo(fark)").getFirst().get(1));
-        assertEquals("fark", LayoutEntry.parseMethodsCalls("bla(test),foo(fark)").get(1).get(1));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            bla -> foo -> test -> fark -> bla(\"test\"),foo(\"fark\")
+            bla -> foo -> test -> fark -> bla(test),foo(fark)
+            """)
+    void parseTwoMethodsWithArguments(String expectedName1, String expectedName2,
+                                      String expectedArg1, String expectedArg2, String input) {
+        assertEquals(2, LayoutEntry.parseMethodsCalls(input).size());
+        assertEquals(expectedName1, LayoutEntry.parseMethodsCalls(input).getFirst().getFirst());
+        assertEquals(expectedName2, LayoutEntry.parseMethodsCalls(input).get(1).getFirst());
+        assertEquals(expectedArg1, LayoutEntry.parseMethodsCalls(input).getFirst().get(1));
+        assertEquals(expectedArg2, LayoutEntry.parseMethodsCalls(input).get(1).get(1));
     }
 
     @ParameterizedTest

--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -74,10 +74,10 @@ class LayoutEntryTest {
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            bla -> bla
-            bla -> bla,
-            _bla.bla.blub -> _bla.bla.blub,
+    @CsvSource(textBlock = """
+            bla , bla
+            bla , bla
+            _bla.bla.blub , _bla.bla.blub
             """)
     void parseSingleMethodWithoutArguments(String expected, String input) {
         assertEquals(1, LayoutEntry.parseMethodsCalls(input).size());
@@ -94,9 +94,9 @@ class LayoutEntryTest {
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            bla -> foo -> test -> fark -> bla(\"test\"),foo(\"fark\")
-            bla -> foo -> test -> fark -> bla(test),foo(fark)
+    @CsvSource(delimiterString = ";", textBlock = """
+            bla ; foo ; test ; fark ; 'bla("test"),foo("fark")'
+            bla ; foo ; test ; fark ; 'bla(test),foo(fark)'
             """)
     void parseTwoMethodsWithArguments(String expectedName1, String expectedName2,
                                       String expectedArg1, String expectedArg2, String input) {

--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -76,8 +76,8 @@ class LayoutEntryTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
             bla, bla
-            bla, bla
-            _bla.bla.blub, _bla.bla.blub
+            bla, 'bla,'
+            _bla.bla.blub, '_bla.bla.blub,'
             """)
     void parseSingleMethodWithoutArguments(String expected, String input) {
         assertEquals(1, LayoutEntry.parseMethodsCalls(input).size());
@@ -94,9 +94,9 @@ class LayoutEntryTest {
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = ";", textBlock = """
-            bla; foo; test; fark; 'bla("test"),foo("fark")'
-            bla; foo; test; fark; 'bla(test),foo(fark)'
+    @CsvSource(textBlock = """
+            bla, foo, test, fark, 'bla(test),foo(fark)'
+            bla, foo, test, fark, 'bla(test),foo(fark)'
             """)
     void parseTwoMethodsWithArguments(String expectedName1, String expectedName2,
                                       String expectedArg1, String expectedArg2, String input) {

--- a/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/LayoutEntryTest.java
@@ -95,15 +95,15 @@ class LayoutEntryTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            bla, foo, test, fark, 'bla("test"),foo("fark")'
-            bla, foo, test, fark, 'bla(test),foo(fark)'
+            bla, test, foo, fark, 'bla("test"),foo("fark")'
+            bla, test, foo, fark, 'bla(test),foo(fark)'
             """)
-    void parseTwoMethodsWithArguments(String expectedName1, String expectedName2,
-                                      String expectedArg1, String expectedArg2, String input) {
+    void parseTwoMethodsWithArguments(String expectedName1, String expectedArg1,
+                                      String expectedName2, String expectedArg2, String input) {
         assertEquals(2, LayoutEntry.parseMethodsCalls(input).size());
         assertEquals(expectedName1, LayoutEntry.parseMethodsCalls(input).getFirst().getFirst());
-        assertEquals(expectedName2, LayoutEntry.parseMethodsCalls(input).get(1).getFirst());
         assertEquals(expectedArg1, LayoutEntry.parseMethodsCalls(input).getFirst().get(1));
+        assertEquals(expectedName2, LayoutEntry.parseMethodsCalls(input).get(1).getFirst());
         assertEquals(expectedArg2, LayoutEntry.parseMethodsCalls(input).get(1).get(1));
     }
 

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
@@ -15,13 +15,13 @@ class AuthorAndsCommaReplacerTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
             # Empty case
-            '' , ''
+            '', ''
             # Single Names don't change
-            'Someone, Van Something' , 'Someone, Van Something'
+            'Someone, Van Something', 'Someone, Van Something'
             # Two names just an &
-            'John von Neumann & Peter Black Brown' , 'John von Neumann and Peter Black Brown'
+            'John von Neumann & Peter Black Brown', 'John von Neumann and Peter Black Brown'
             # Three names put a comma:
-            'von Neumann, John, Smith, John & Black Brown, Peter' , 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, John, Smith, John & Black Brown, Peter', 'von Neumann, John and Smith, John and Black Brown, Peter'
             """)
     void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorAndsCommaReplacer();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
@@ -13,11 +13,15 @@ class AuthorAndsCommaReplacerTest {
      * Test method for {@link org.jabref.logic.layout.format.AuthorAndsCommaReplacer#format(java.lang.String)}.
      */
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            '' -> ''
-            'Someone, Van Something' -> 'Someone, Van Something'
-            'John von Neumann & Peter Black Brown' -> 'John von Neumann and Peter Black Brown'
-            'von Neumann, John, Smith, John & Black Brown, Peter' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+    @CsvSource(textBlock = """
+            # Empty case
+            '' , ''
+            # Single Names don't change
+            'Someone, Van Something' , 'Someone, Van Something'
+            # Two names just an &
+            'John von Neumann & Peter Black Brown' , 'John von Neumann and Peter Black Brown'
+            # Three names put a comma:
+            'von Neumann, John, Smith, John & Black Brown, Peter' , 'von Neumann, John and Smith, John and Black Brown, Peter'
             """)
     void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorAndsCommaReplacer();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorAndsCommaReplacerTest.java
@@ -2,7 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,22 +12,15 @@ class AuthorAndsCommaReplacerTest {
     /**
      * Test method for {@link org.jabref.logic.layout.format.AuthorAndsCommaReplacer#format(java.lang.String)}.
      */
-    @Test
-    void format() {
-        LayoutFormatter a = new AuthorAndsCommaReplacer();
-
-        // Empty case
-        assertEquals("", a.format(""));
-
-        // Single Names don't change
-        assertEquals("Someone, Van Something", a.format("Someone, Van Something"));
-
-        // Two names just an &
-        assertEquals("John von Neumann & Peter Black Brown",
-                a.format("John von Neumann and Peter Black Brown"));
-
-        // Three names put a comma:
-        assertEquals("von Neumann, John, Smith, John & Black Brown, Peter",
-                a.format("von Neumann, John and Smith, John and Black Brown, Peter"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            '' -> ''
+            'Someone, Van Something' -> 'Someone, Van Something'
+            'John von Neumann & Peter Black Brown' -> 'John von Neumann and Peter Black Brown'
+            'von Neumann, John, Smith, John & Black Brown, Peter' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+            """)
+    void format(String expected, String input) {
+        LayoutFormatter formatter = new AuthorAndsCommaReplacer();
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommasTest.java
@@ -12,14 +12,14 @@ class AuthorFirstAbbrLastCommasTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
             # Empty case
-            '' , ''
+            '', ''
             # Single Names
-            'V. S. Someone' , 'Someone, Van Something'
+            'V. S. Someone', 'Someone, Van Something'
             # Two names
-            'J. von Neumann and P. Black Brown' , 'John von Neumann and Black Brown, Peter'
+            'J. von Neumann and P. Black Brown', 'John von Neumann and Black Brown, Peter'
             # Three names
-            'J. von Neumann, J. Smith and P. Black Brown' , 'von Neumann, John and Smith, John and Black Brown, Peter'
-            'J. von Neumann, J. Smith and P. Black Brown' , 'John von Neumann and John Smith and Black Brown, Peter'
+            'J. von Neumann, J. Smith and P. Black Brown', 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'J. von Neumann, J. Smith and P. Black Brown', 'John von Neumann and John Smith and Black Brown, Peter'
             """)
     void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorFirstAbbrLastCommas();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommasTest.java
@@ -10,12 +10,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class AuthorFirstAbbrLastCommasTest {
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            '' -> ''
-            'V. S. Someone' -> 'Someone, Van Something'
-            'J. von Neumann and P. Black Brown' -> 'John von Neumann and Black Brown, Peter'
-            'J. von Neumann, J. Smith and P. Black Brown' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
-            'J. von Neumann, J. Smith and P. Black Brown' -> 'John von Neumann and John Smith and Black Brown, Peter'
+    @CsvSource(textBlock = """
+            # Empty case
+            '' , ''
+            # Single Names
+            'V. S. Someone' , 'Someone, Van Something'
+            # Two names
+            'J. von Neumann and P. Black Brown' , 'John von Neumann and Black Brown, Peter'
+            # Three names
+            'J. von Neumann, J. Smith and P. Black Brown' , 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'J. von Neumann, J. Smith and P. Black Brown' , 'John von Neumann and John Smith and Black Brown, Peter'
             """)
     void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorFirstAbbrLastCommas();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorFirstAbbrLastCommasTest.java
@@ -2,31 +2,23 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AuthorFirstAbbrLastCommasTest {
 
-    @Test
-    void format() {
-        LayoutFormatter a = new AuthorFirstAbbrLastCommas();
-
-        // Empty case
-        assertEquals("", a.format(""));
-
-        // Single Names
-        assertEquals("V. S. Someone", a.format("Someone, Van Something"));
-
-        // Two names
-        assertEquals("J. von Neumann and P. Black Brown", a
-                .format("John von Neumann and Black Brown, Peter"));
-
-        // Three names
-        assertEquals("J. von Neumann, J. Smith and P. Black Brown", a
-                .format("von Neumann, John and Smith, John and Black Brown, Peter"));
-
-        assertEquals("J. von Neumann, J. Smith and P. Black Brown", a
-                .format("John von Neumann and John Smith and Black Brown, Peter"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            '' -> ''
+            'V. S. Someone' -> 'Someone, Van Something'
+            'J. von Neumann and P. Black Brown' -> 'John von Neumann and Black Brown, Peter'
+            'J. von Neumann, J. Smith and P. Black Brown' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'J. von Neumann, J. Smith and P. Black Brown' -> 'John von Neumann and John Smith and Black Brown, Peter'
+            """)
+    void format(String expected, String input) {
+        LayoutFormatter formatter = new AuthorFirstAbbrLastCommas();
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrCommasTest.java
@@ -2,7 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,25 +12,20 @@ class AuthorLastFirstAbbrCommasTest {
     /**
      * Test method for {@link org.jabref.logic.layout.format.AuthorLastFirstAbbrCommas#format(java.lang.String)}.
      */
-    @Test
-    void format() {
-        LayoutFormatter a = new AuthorLastFirstAbbrCommas();
-
-        // Empty case
-        assertEquals("", a.format(""));
-
-        // Single Names
-        assertEquals("Someone, V. S.", a.format("Van Something Someone"));
-
-        // Two names
-        assertEquals("von Neumann, J. and Black Brown, P.", a
-                .format("John von Neumann and Black Brown, Peter"));
-
-        // Three names
-        assertEquals("von Neumann, J., Smith, J. and Black Brown, P.", a
-                .format("von Neumann, John and Smith, John and Black Brown, Peter"));
-
-        assertEquals("von Neumann, J., Smith, J. and Black Brown, P.", a
-                .format("John von Neumann and John Smith and Black Brown, Peter"));
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            # Empty case
+            '' , ''
+            # Single Names
+            'Someone, V. S.' , 'Van Something Someone'
+            # Two Names
+            'von Neumann, J. and Black Brown, P.' , 'John von Neumann and Black Brown, Peter'
+            # Three Names
+            'von Neumann, J., Smith, J. and Black Brown, P.' , 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.' , 'John von Neumann and John Smith and Black Brown, Peter'
+            """)
+    void format(String expected, String input) {
+        LayoutFormatter formatter = new AuthorLastFirstAbbrCommas();
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstAbbrCommasTest.java
@@ -15,14 +15,14 @@ class AuthorLastFirstAbbrCommasTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
             # Empty case
-            '' , ''
+            '', ''
             # Single Names
-            'Someone, V. S.' , 'Van Something Someone'
+            'Someone, V. S.', 'Van Something Someone'
             # Two Names
-            'von Neumann, J. and Black Brown, P.' , 'John von Neumann and Black Brown, Peter'
+            'von Neumann, J. and Black Brown, P.', 'John von Neumann and Black Brown, Peter'
             # Three Names
-            'von Neumann, J., Smith, J. and Black Brown, P.' , 'von Neumann, John and Smith, John and Black Brown, Peter'
-            'von Neumann, J., Smith, J. and Black Brown, P.' , 'John von Neumann and John Smith and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.', 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.', 'John von Neumann and John Smith and Black Brown, Peter'
             """)
     void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorLastFirstAbbrCommas();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
@@ -2,7 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,25 +12,16 @@ class AuthorLastFirstCommasTest {
     /**
      * Test method for {@link org.jabref.logic.layout.format.AuthorLastFirstCommas#format(java.lang.String)}.
      */
-    @Test
-    void format() {
-        LayoutFormatter a = new AuthorLastFirstCommas();
-
-        // Empty case
-        assertEquals("", a.format(""));
-
-        // Single Names
-        assertEquals("Someone, Van Something", a.format("Van Something Someone"));
-
-        // Two names
-        assertEquals("von Neumann, John and Black Brown, Peter", a
-                .format("John von Neumann and Black Brown, Peter"));
-
-        // Three names
-        assertEquals("von Neumann, John, Smith, John and Black Brown, Peter", a
-                .format("von Neumann, John and Smith, John and Black Brown, Peter"));
-
-        assertEquals("von Neumann, John, Smith, John and Black Brown, Peter", a
-                .format("John von Neumann and John Smith and Black Brown, Peter"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            '' -> ''
+            'Someone, V. S.' -> 'Van Something Someone'
+            'von Neumann, J. and Black Brown, P.' -> 'John von Neumann and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.' -> 'John von Neumann and John Smith and Black Brown, Peter'
+            """)
+    void format(String expected, String input) {
+        LayoutFormatter formatter = new AuthorLastFirstAbbrCommas();
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
@@ -13,12 +13,16 @@ class AuthorLastFirstCommasTest {
      * Test method for {@link org.jabref.logic.layout.format.AuthorLastFirstCommas#format(java.lang.String)}.
      */
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            '' -> ''
-            'Someone, V. S.' -> 'Van Something Someone'
-            'von Neumann, J. and Black Brown, P.' -> 'John von Neumann and Black Brown, Peter'
-            'von Neumann, J., Smith, J. and Black Brown, P.' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
-            'von Neumann, J., Smith, J. and Black Brown, P.' -> 'John von Neumann and John Smith and Black Brown, Peter'
+    @CsvSource(textBlock = """
+            # Empty case
+            '' , ''
+            # Single Names
+            'Someone, V. S.' , 'Van Something Someone'
+            # Two names
+            'von Neumann, J. and Black Brown, P.' , 'John von Neumann and Black Brown, Peter'
+            # Three names
+            'von Neumann, J., Smith, J. and Black Brown, P.' , 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.' , 'John von Neumann and John Smith and Black Brown, Peter'
             """)
     void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorLastFirstAbbrCommas();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstCommasTest.java
@@ -15,14 +15,14 @@ class AuthorLastFirstCommasTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
             # Empty case
-            '' , ''
+            '', ''
             # Single Names
-            'Someone, V. S.' , 'Van Something Someone'
+            'Someone, V. S.', 'Van Something Someone'
             # Two names
-            'von Neumann, J. and Black Brown, P.' , 'John von Neumann and Black Brown, Peter'
+            'von Neumann, J. and Black Brown, P.', 'John von Neumann and Black Brown, Peter'
             # Three names
-            'von Neumann, J., Smith, J. and Black Brown, P.' , 'von Neumann, John and Smith, John and Black Brown, Peter'
-            'von Neumann, J., Smith, J. and Black Brown, P.' , 'John von Neumann and John Smith and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.', 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, J., Smith, J. and Black Brown, P.', 'John von Neumann and John Smith and Black Brown, Peter'
             """)
     void format(String expected, String input) {
         LayoutFormatter formatter = new AuthorLastFirstAbbrCommas();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommasTest.java
@@ -2,7 +2,8 @@ package org.jabref.logic.layout.format;
 
 import org.jabref.logic.layout.LayoutFormatter;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,25 +12,16 @@ class AuthorLastFirstOxfordCommasTest {
     /**
      * Test method for {@link org.jabref.logic.layout.format.AuthorLastFirstOxfordCommas#format(java.lang.String)}.
      */
-    @Test
-    void format() {
-        LayoutFormatter a = new AuthorLastFirstOxfordCommas();
-
-        // Empty case
-        assertEquals("", a.format(""));
-
-        // Single Names
-        assertEquals("Someone, Van Something", a.format("Van Something Someone"));
-
-        // Two names
-        assertEquals("von Neumann, John and Black Brown, Peter", a
-                .format("John von Neumann and Black Brown, Peter"));
-
-        // Three names
-        assertEquals("von Neumann, John, Smith, John, and Black Brown, Peter", a
-                .format("von Neumann, John and Smith, John and Black Brown, Peter"));
-
-        assertEquals("von Neumann, John, Smith, John, and Black Brown, Peter", a
-                .format("John von Neumann and John Smith and Black Brown, Peter"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            '' -> ''
+            'Someone, Van Something' -> 'Van Something Someone'
+            'von Neumann, John and Black Brown, Peter' -> 'John von Neumann and Black Brown, Peter'
+            'von Neumann, John, Smith, John, and Black Brown, Peter' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, John, Smith, John, and Black Brown, Peter' -> 'John von Neumann and John Smith and Black Brown, Peter'
+            """)
+    void format_cases(String expected, String input) {
+        LayoutFormatter formatter = new AuthorLastFirstOxfordCommas();
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommasTest.java
@@ -15,14 +15,14 @@ class AuthorLastFirstOxfordCommasTest {
     @ParameterizedTest
     @CsvSource(textBlock = """
             # Empty case
-            '' , ''
+            '', ''
             # Single Names
-            'Someone, Van Something' , 'Van Something Someone'
+            'Someone, Van Something', 'Van Something Someone'
             # Two names
-            'von Neumann, John and Black Brown, Peter' , 'John von Neumann and Black Brown, Peter'
+            'von Neumann, John and Black Brown, Peter', 'John von Neumann and Black Brown, Peter'
             # Three names
-            'von Neumann, John, Smith, John, and Black Brown, Peter' , 'von Neumann, John and Smith, John and Black Brown, Peter'
-            'von Neumann, John, Smith, John, and Black Brown, Peter' , 'John von Neumann and John Smith and Black Brown, Peter'
+            'von Neumann, John, Smith, John, and Black Brown, Peter', 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, John, Smith, John, and Black Brown, Peter', 'John von Neumann and John Smith and Black Brown, Peter'
             """)
     void format_cases(String expected, String input) {
         LayoutFormatter formatter = new AuthorLastFirstOxfordCommas();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommasTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/AuthorLastFirstOxfordCommasTest.java
@@ -13,12 +13,16 @@ class AuthorLastFirstOxfordCommasTest {
      * Test method for {@link org.jabref.logic.layout.format.AuthorLastFirstOxfordCommas#format(java.lang.String)}.
      */
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            '' -> ''
-            'Someone, Van Something' -> 'Van Something Someone'
-            'von Neumann, John and Black Brown, Peter' -> 'John von Neumann and Black Brown, Peter'
-            'von Neumann, John, Smith, John, and Black Brown, Peter' -> 'von Neumann, John and Smith, John and Black Brown, Peter'
-            'von Neumann, John, Smith, John, and Black Brown, Peter' -> 'John von Neumann and John Smith and Black Brown, Peter'
+    @CsvSource(textBlock = """
+            # Empty case
+            '' , ''
+            # Single Names
+            'Someone, Van Something' , 'Van Something Someone'
+            # Two names
+            'von Neumann, John and Black Brown, Peter' , 'John von Neumann and Black Brown, Peter'
+            # Three names
+            'von Neumann, John, Smith, John, and Black Brown, Peter' , 'von Neumann, John and Smith, John and Black Brown, Peter'
+            'von Neumann, John, Smith, John, and Black Brown, Peter' , 'John von Neumann and John Smith and Black Brown, Peter'
             """)
     void format_cases(String expected, String input) {
         LayoutFormatter formatter = new AuthorLastFirstOxfordCommas();

--- a/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
@@ -25,15 +25,15 @@ class CompositeFormatTest {
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            John Flynn and Sabine Gartska -> John Flynn and Sabine Gartska
-            Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee -> Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee
+    @CsvSource(textBlock = """
+            John Flynn and Sabine Gartska , John Flynn and Sabine Gartska
+            Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee , Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee
             """)
     void doubleComposite(String inputForFirst, String inputForComposite) {
         LayoutFormatter f = new CompositeFormat(new AuthorOrgSci(), new NoSpaceBetweenAbbreviations());
         LayoutFormatter first = new AuthorOrgSci();
         LayoutFormatter second = new NoSpaceBetweenAbbreviations();
-
+        
         assertEquals(second.format(first.format(inputForFirst)), f.format(inputForComposite));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
@@ -33,7 +33,7 @@ class CompositeFormatTest {
         LayoutFormatter f = new CompositeFormat(new AuthorOrgSci(), new NoSpaceBetweenAbbreviations());
         LayoutFormatter first = new AuthorOrgSci();
         LayoutFormatter second = new NoSpaceBetweenAbbreviations();
-        
+
         assertEquals(second.format(first.format(inputForFirst)), f.format(inputForComposite));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
@@ -26,8 +26,8 @@ class CompositeFormatTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            John Flynn and Sabine Gartska , John Flynn and Sabine Gartska
-            Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee , Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee
+            John Flynn and Sabine Gartska, John Flynn and Sabine Gartska
+            Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee, Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee
             """)
     void doubleComposite(String inputForFirst, String inputForComposite) {
         LayoutFormatter f = new CompositeFormat(new AuthorOrgSci(), new NoSpaceBetweenAbbreviations());

--- a/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/CompositeFormatTest.java
@@ -3,6 +3,8 @@ package org.jabref.logic.layout.format;
 import org.jabref.logic.layout.LayoutFormatter;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -22,15 +24,16 @@ class CompositeFormatTest {
         assertEquals("BAff", f.format("f"));
     }
 
-    @Test
-    void doubleComposite() {
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            John Flynn and Sabine Gartska -> John Flynn and Sabine Gartska
+            Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee -> Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee
+            """)
+    void doubleComposite(String inputForFirst, String inputForComposite) {
         LayoutFormatter f = new CompositeFormat(new AuthorOrgSci(), new NoSpaceBetweenAbbreviations());
         LayoutFormatter first = new AuthorOrgSci();
         LayoutFormatter second = new NoSpaceBetweenAbbreviations();
 
-        assertEquals(second.format(first.format("John Flynn and Sabine Gartska")),
-                f.format("John Flynn and Sabine Gartska"));
-        assertEquals(second.format(first.format("Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee")),
-                f.format("Sa Makridakis and Sa Ca Wheelwright and Va Ea McGee"));
+        assertEquals(second.format(first.format(inputForFirst)), f.format(inputForComposite));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -1,12 +1,16 @@
 package org.jabref.logic.layout.format;
 
+import java.util.stream.Stream;
+
 import org.jabref.logic.layout.LayoutFormatter;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,30 +27,29 @@ class RTFCharsTest {
         formatter = null;
     }
 
-    @Test
-    void basicFormat() {
-        assertEquals("", formatter.format(""));
-
-        assertEquals("hallo", formatter.format("hallo"));
-
-        assertEquals("R\\u233eflexions sur le timing de la quantit\\u233e",
-                formatter.format("Réflexions sur le timing de la quantité"));
-
-        assertEquals("h\\'e1llo", formatter.format("h\\'allo"));
-        assertEquals("h\\'e1llo", formatter.format("h\\'allo"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            '' -> ''
+            hallo -> hallo
+            R\\u233eflexions sur le timing de la quantit\\u233e -> Réflexions sur le timing de la quantité
+            h\\'e1llo -> h\\'allo
+            """)
+    void basicFormat(String expected, String input) {
+        assertEquals(expected, formatter.format(input));
     }
 
-    @Test
-    void laTeXHighlighting() {
-        assertEquals("{\\i hallo}", formatter.format("\\emph{hallo}"));
-        assertEquals("{\\i hallo}", formatter.format("{\\emph hallo}"));
-        assertEquals("An article title with {\\i a book title} emphasized", formatter.format("An article title with \\emph{a book title} emphasized"));
-
-        assertEquals("{\\i hallo}", formatter.format("\\textit{hallo}"));
-        assertEquals("{\\i hallo}", formatter.format("{\\textit hallo}"));
-
-        assertEquals("{\\b hallo}", formatter.format("\\textbf{hallo}"));
-        assertEquals("{\\b hallo}", formatter.format("{\\textbf hallo}"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            {\\i hallo} -> \\emph{hallo}
+            {\\i hallo} -> {\\emph hallo}
+            An article title with {\\i a book title} emphasized -> An article title with \\emph{a book title} emphasized
+            {\\i hallo} -> \\textit{hallo}
+            {\\i hallo} -> {\\textit hallo}
+            {\\b hallo} -> \\textbf{hallo}
+            {\\b hallo} -> {\\textbf hallo}
+            """)
+    void laTeXHighlighting(String expected, String input) {
+        assertEquals(expected, formatter.format(input));
     }
 
     @Test
@@ -93,151 +96,210 @@ class RTFCharsTest {
                 formatter.format("Pchnąć w tę łódź jeża lub ośm skrzyń fig"));
     }
 
-    @Test
-    void specialCharacters() {
-        assertEquals("\\'f3", formatter.format("\\'{o}")); // ó
-        assertEquals("\\'f2", formatter.format("\\`{o}")); // ò
-        assertEquals("\\'f4", formatter.format("\\^{o}")); // ô
-        assertEquals("\\'f6", formatter.format("\\\"{o}")); // ö
-        assertEquals("\\u245o", formatter.format("\\~{o}")); // õ
-        assertEquals("\\u333o", formatter.format("\\={o}"));
-        assertEquals("\\u335o", formatter.format("{\\uo}"));
-        assertEquals("\\u231c", formatter.format("{\\cc}")); // ç
-        assertEquals("{\\u339oe}", formatter.format("{\\oe}"));
-        assertEquals("{\\u338OE}", formatter.format("{\\OE}"));
-        assertEquals("{\\u230ae}", formatter.format("{\\ae}")); // æ
-        assertEquals("{\\u198AE}", formatter.format("{\\AE}")); // Æ
+    static Stream<Arguments> specialCharacterCases() {
+        return Stream.of(
+                Arguments.of("\\'f3", "\\'{o}"), // ó
+                Arguments.of("\\'f2", "\\`{o}"), // ò
+                Arguments.of("\\'f4", "\\^{o}"), // ô
+                Arguments.of("\\'f6", "\\\"{o}"), // ö
+                Arguments.of("\\u245o", "\\~{o}"), // õ
+                Arguments.of("\\u333o", "\\={o}"),
+                Arguments.of("\\u335o", "{\\uo}"),
+                Arguments.of("\\u231c", "{\\cc}"), // ç
+                Arguments.of("{\\u339oe}", "{\\oe}"),
+                Arguments.of("{\\u338OE}", "{\\OE}"),
+                Arguments.of("{\\u230ae}", "{\\ae}"), // æ
+                Arguments.of("{\\u198AE}", "{\\AE}"), // Æ
 
-        assertEquals("", formatter.format("\\.{o}")); // ???
-        assertEquals("", formatter.format("\\vo")); // ???
-        assertEquals("", formatter.format("\\Ha")); // ã // ???
-        assertEquals("", formatter.format("\\too"));
-        assertEquals("", formatter.format("\\do")); // ???
-        assertEquals("", formatter.format("\\bo")); // ???
-        assertEquals("\\u229a", formatter.format("{\\aa}")); // å
-        assertEquals("\\u197A", formatter.format("{\\AA}")); // Å
-        assertEquals("\\u248o", formatter.format("{\\o}")); // ø
-        assertEquals("\\u216O", formatter.format("{\\O}")); // Ø
-        assertEquals("\\u322l", formatter.format("{\\l}"));
-        assertEquals("\\u321L", formatter.format("{\\L}"));
-        assertEquals("\\u223ss", formatter.format("{\\ss}")); // ß
-        assertEquals("\\u191?", formatter.format("\\`?")); // ¿
-        assertEquals("\\u161!", formatter.format("\\`!")); // ¡
+                Arguments.of("", "\\.{o}"), // ???
+                Arguments.of("", "\\vo"), // ???
+                Arguments.of("", "\\Ha"), // ã // ???
+                Arguments.of("", "\\too"),
+                Arguments.of("", "\\do"), // ???
+                Arguments.of("", "\\bo"), // ???
 
-        assertEquals("", formatter.format("\\dag"));
-        assertEquals("", formatter.format("\\ddag"));
-        assertEquals("\\u167S", formatter.format("{\\S}")); // §
-        assertEquals("\\u182P", formatter.format("{\\P}")); // ¶
-        assertEquals("\\u169?", formatter.format("{\\copyright}")); // ©
-        assertEquals("\\u163?", formatter.format("{\\pounds}")); // £
+                Arguments.of("\\u229a", "{\\aa}"), // å
+                Arguments.of("\\u197A", "{\\AA}"), // Å
+                Arguments.of("\\u248o", "{\\o}"), // ø
+                Arguments.of("\\u216O", "{\\O}"), // Ø
+                Arguments.of("\\u322l", "{\\l}"),
+                Arguments.of("\\u321L", "{\\L}"),
+                Arguments.of("\\u223ss", "{\\ss}"), // ß
+                Arguments.of("\\u191?", "\\`?"), // ¿
+                Arguments.of("\\u161!", "\\`!"), // ¡
+
+                Arguments.of("", "\\dag"),
+                Arguments.of("", "\\ddag"),
+                Arguments.of("\\u167S", "{\\S}"), // §
+                Arguments.of("\\u182P", "{\\P}"), // ¶
+                Arguments.of("\\u169?", "{\\copyright}"), // ©
+                Arguments.of("\\u163?", "{\\pounds}") // £
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("specialCharacterCases")
+    void specialCharacters(String expected, String input) {
+        assertEquals(expected, formatter.format(input));
     }
 
     @ParameterizedTest(name = "specialChar={0}, formattedStr={1}")
-    @CsvSource({
-            "ÀÁÂÃÄĀĂĄ, \\u192A\\u193A\\u194A\\u195A\\u196A\\u256A\\u258A\\u260A", // A
-            "àáâãäåāăą, \\u224a\\u225a\\u226a\\u227a\\u228a\\u229a\\u257a\\u259a\\u261a", // a
-            "ÇĆĈĊČ, \\u199C\\u262C\\u264C\\u266C\\u268C", // C
-            "çćĉċč, \\u231c\\u263c\\u265c\\u267c\\u269c", // c
-            "ÐĐ, \\u208D\\u272D", // D
-            "ðđ, \\u240d\\u273d", // d
-            "ÈÉÊËĒĔĖĘĚ, \\u200E\\u201E\\u202E\\u203E\\u274E\\u276E\\u278E\\u280E\\u282E", // E
-            "èéêëēĕėęě, \\u232e\\u233e\\u234e\\u235e\\u275e\\u277e\\u279e\\u281e\\u283e", // e
-            "ĜĞĠĢŊ, \\u284G\\u286G\\u288G\\u290G\\u330G", // G
-            "ĝğġģŋ, \\u285g\\u287g\\u289g\\u291g\\u331g", // g
-            "ĤĦ, \\u292H\\u294H", // H
-            "ĥħ, \\u293h\\u295h", // h
-            "ÌÍÎÏĨĪĬĮİ, \\u204I\\u205I\\u206I\\u207I\\u296I\\u298I\\u300I\\u302I\\u304I", // I
-            "ìíîïĩīĭį, \\u236i\\u237i\\u238i\\u239i\\u297i\\u299i\\u301i\\u303i", // i
-            "Ĵ, \\u308J", // J
-            "ĵ, \\u309j", // j
-            "Ķ, \\u310K", // K
-            "ķ, \\u311k", // k
-            "ĹĻĿ, \\u313L\\u315L\\u319L", // L
-            "ĺļŀł, \\u314l\\u316l\\u320l\\u322l", // l
-            "ÑŃŅŇ, \\u209N\\u323N\\u325N\\u327N", // N
-            "ñńņň, \\u241n\\u324n\\u326n\\u328n", // n
-            "ÒÓÔÕÖØŌŎ, \\u210O\\u211O\\u212O\\u213O\\u214O\\u216O\\u332O\\u334O", // O
-            "òóôõöøōŏ, \\u242o\\u243o\\u244o\\u245o\\u246o\\u248o\\u333o\\u335o", // o
-            "ŔŖŘ, \\u340R\\u342R\\u344R", // R
-            "ŕŗř, \\u341r\\u343r\\u345r", // r
-            "ŚŜŞŠ, \\u346S\\u348S\\u350S\\u352S", // S
-            "śŝşš, \\u347s\\u349s\\u351s\\u353s", // s
-            "ŢŤŦ, \\u354T\\u356T\\u358T", // T
-            "ţŧ, \\u355t\\u359t", // t
-            "ÙÚÛÜŨŪŬŮŲ, \\u217U\\u218U\\u219U\\u220U\\u360U\\u362U\\u364U\\u366U\\u370U", // U
-            "ùúûũūŭůų, \\u249u\\u250u\\u251u\\u361u\\u363u\\u365u\\u367u\\u371u", // u
-            "Ŵ, \\u372W", // W
-            "ŵ, \\u373w", // w
-            "ŶŸÝ, \\u374Y\\u376Y\\u221Y", // Y
-            "ŷÿ, \\u375y\\u255y", // y
-            "ŹŻŽ, \\u377Z\\u379Z\\u381Z", // Z
-            "źżž, \\u378z\\u380z\\u382z", // z
-            "Æ, \\u198AE", // AE
-            "æ, \\u230ae", // ae
-            "Œ, \\u338OE", // OE
-            "œ, \\u339oe", // oe
-            "Þ, \\u222TH", // TH
-            "ß, \\u223ss", // ss
-            "¡, \\u161!" // !
-    })
+    @CsvSource(delimiterString = "->", textBlock = """
+            # A
+            ÀÁÂÃÄĀĂĄ -> \\u192A\\u193A\\u194A\\u195A\\u196A\\u256A\\u258A\\u260A
+            # a
+            àáâãäåāăą -> \\u224a\\u225a\\u226a\\u227a\\u228a\\u229a\\u257a\\u259a\\u261a
+            # C
+            ÇĆĈĊČ -> \\u199C\\u262C\\u264C\\u266C\\u268C
+            # c
+            çćĉċč -> \\u231c\\u263c\\u265c\\u267c\\u269c
+            # D
+            ÐĐ -> \\u208D\\u272D
+            # d
+            ðđ -> \\u240d\\u273d
+            # E
+            ÈÉÊËĒĔĖĘĚ -> \\u200E\\u201E\\u202E\\u203E\\u274E\\u276E\\u278E\\u280E\\u282E
+            # e
+            èéêëēĕėęě -> \\u232e\\u233e\\u234e\\u235e\\u275e\\u277e\\u279e\\u281e\\u283e
+            # G
+            ĜĞĠĢŊ -> \\u284G\\u286G\\u288G\\u290G\\u330G
+            # g
+            ĝğġģŋ -> \\u285g\\u287g\\u289g\\u291g\\u331g
+            # H
+            ĤĦ -> \\u292H\\u294H
+            # h
+            ĥħ -> \\u293h\\u295h
+            # I
+            ÌÍÎÏĨĪĬĮİ -> \\u204I\\u205I\\u206I\\u207I\\u296I\\u298I\\u300I\\u302I\\u304I
+            # i
+            ìíîïĩīĭį -> \\u236i\\u237i\\u238i\\u239i\\u297i\\u299i\\u301i\\u303i
+            # J
+            Ĵ -> \\u308J
+            # j
+            ĵ -> \\u309j
+            # K
+            Ķ -> \\u310K
+            # k
+            ķ -> \\u311k
+            # L
+            ĹĻĿ -> \\u313L\\u315L\\u319L
+            # l
+            ĺļŀł -> \\u314l\\u316l\\u320l\\u322l
+            # N
+            ÑŃŅŇ -> \\u209N\\u323N\\u325N\\u327N
+            # n
+            ñńņň -> \\u241n\\u324n\\u326n\\u328n
+            # O
+            ÒÓÔÕÖØŌŎ -> \\u210O\\u211O\\u212O\\u213O\\u214O\\u216O\\u332O\\u334O
+            # o
+            òóôõöøōŏ -> \\u242o\\u243o\\u244o\\u245o\\u246o\\u248o\\u333o\\u335o
+            # R
+            ŔŖŘ -> \\u340R\\u342R\\u344R
+            # r
+            ŕŗř -> \\u341r\\u343r\\u345r
+            # S
+            ŚŜŞŠ -> \\u346S\\u348S\\u350S\\u352S
+            # s
+            śŝşš -> \\u347s\\u349s\\u351s\\u353s
+            # T
+            ŢŤŦ -> \\u354T\\u356T\\u358T
+            # t
+            ţŧ -> \\u355t\\u359t
+            # U
+            ÙÚÛÜŨŪŬŮŲ -> \\u217U\\u218U\\u219U\\u220U\\u360U\\u362U\\u364U\\u366U\\u370U
+            # u
+            ùúûũūŭůų -> \\u249u\\u250u\\u251u\\u361u\\u363u\\u365u\\u367u\\u371u
+            # W
+            Ŵ -> \\u372W
+            # w
+            ŵ -> \\u373w
+            # Y
+            ŶŸÝ -> \\u374Y\\u376Y\\u221Y
+            # y
+            ŷÿ -> \\u375y\\u255y
+            # Z
+            ŹŻŽ -> \\u377Z\\u379Z\\u381Z
+            # z
+            źżž -> \\u378z\\u380z\\u382z
+            # AE
+            Æ -> \\u198AE
+            # ae
+            æ -> \\u230ae
+            # OE
+            Œ -> \\u338OE
+            # oe
+            œ -> \\u339oe
+            # TH
+            Þ -> \\u222TH
+            # ss
+            ß -> \\u223ss
+            # !
+            ¡ -> \\u161!
+            """)
     void moreSpecialCharacters(String specialChar, String expectedResult) {
         String formattedStr = formatter.format(specialChar);
         assertEquals(expectedResult, formattedStr);
     }
 
-    @Test
-    void rtfCharacters() {
-        assertEquals("\\'e0", formatter.format("\\`{a}"));
-        assertEquals("\\'e8", formatter.format("\\`{e}"));
-        assertEquals("\\'ec", formatter.format("\\`{i}"));
-        assertEquals("\\'f2", formatter.format("\\`{o}"));
-        assertEquals("\\'f9", formatter.format("\\`{u}"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+             \\'e0-> \\`{a}
+             \\'e8-> \\`{e}
+             \\'ec-> \\`{i}
+             \\'f2-> \\`{o}
+             \\'f9-> \\`{u}
 
-        assertEquals("\\'e1", formatter.format("\\'a"));
-        assertEquals("\\'e9", formatter.format("\\'e"));
-        assertEquals("\\'ed", formatter.format("\\'i"));
-        assertEquals("\\'f3", formatter.format("\\'o"));
-        assertEquals("\\'fa", formatter.format("\\'u"));
+             \\'e1-> \\'a
+             \\'e9-> \\'e
+             \\'ed-> \\'i
+             \\'f3-> \\'o
+             \\'fa-> \\'u
 
-        assertEquals("\\'e2", formatter.format("\\^a"));
-        assertEquals("\\'ea", formatter.format("\\^e"));
-        assertEquals("\\'ee", formatter.format("\\^i"));
-        assertEquals("\\'f4", formatter.format("\\^o"));
-        assertEquals("\\'fa", formatter.format("\\^u"));
+             \\'e2-> \\^a
+             \\'ea-> \\^e
+             \\'ee-> \\^i
+             \\'f4-> \\^o
+             \\'fa-> \\^u
 
-        assertEquals("\\'e4", formatter.format("\\\"a"));
-        assertEquals("\\'eb", formatter.format("\\\"e"));
-        assertEquals("\\'ef", formatter.format("\\\"i"));
-        assertEquals("\\'f6", formatter.format("\\\"o"));
-        assertEquals("\\u252u", formatter.format("\\\"u"));
+             \\'e4-> \\\"a
+             \\'eb-> \\\"e
+             \\'ef-> \\\"i
+             \\'f6-> \\\"o
+             \\u252u-> \\\"u
 
-        assertEquals("\\'f1", formatter.format("\\~n"));
+             \\'f1-> \\~n
+            """)
+    void rtfCharacters(String expected, String input) {
+        assertEquals(expected, formatter.format(input));
     }
 
-    @Test
-    void rTFCharactersCapital() {
-        assertEquals("\\'c0", formatter.format("\\`A"));
-        assertEquals("\\'c8", formatter.format("\\`E"));
-        assertEquals("\\'cc", formatter.format("\\`I"));
-        assertEquals("\\'d2", formatter.format("\\`O"));
-        assertEquals("\\'d9", formatter.format("\\`U"));
+    @ParameterizedTest
+    @CsvSource(delimiterString = "->", textBlock = """
+            \\'c0 -> \\`A
+            \\'c8 -> \\`E
+            \\'cc -> \\`I
+            \\'d2 -> \\`O
+            \\'d9 -> \\`U
 
-        assertEquals("\\'c1", formatter.format("\\'A"));
-        assertEquals("\\'c9", formatter.format("\\'E"));
-        assertEquals("\\'cd", formatter.format("\\'I"));
-        assertEquals("\\'d3", formatter.format("\\'O"));
-        assertEquals("\\'da", formatter.format("\\'U"));
+            \\'c1 -> \\'A
+            \\'c9 -> \\'E
+            \\'cd -> \\'I
+            \\'d3 -> \\'O
+            \\'da -> \\'U
 
-        assertEquals("\\'c2", formatter.format("\\^A"));
-        assertEquals("\\'ca", formatter.format("\\^E"));
-        assertEquals("\\'ce", formatter.format("\\^I"));
-        assertEquals("\\'d4", formatter.format("\\^O"));
-        assertEquals("\\'db", formatter.format("\\^U"));
+            \\'c2 -> \\^A
+            \\'ca -> \\^E
+            \\'ce -> \\^I
+            \\'d4 -> \\^O
+            \\'db -> \\^U
 
-        assertEquals("\\'c4", formatter.format("\\\"A"));
-        assertEquals("\\'cb", formatter.format("\\\"E"));
-        assertEquals("\\'cf", formatter.format("\\\"I"));
-        assertEquals("\\'d6", formatter.format("\\\"O"));
-        assertEquals("\\'dc", formatter.format("\\\"U"));
+            \\'c4 -> \\\"A
+            \\'cb -> \\\"E
+            \\'cf -> \\\"I
+            \\'d6 -> \\\"O
+            \\'dc -> \\\"U
+            """)
+    void rTFCharactersCapital(String expected, String input) {
+        assertEquals(expected, formatter.format(input));
     }
 }

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -28,25 +28,25 @@ class RTFCharsTest {
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            '' -> ''
-            hallo -> hallo
-            R\\u233eflexions sur le timing de la quantit\\u233e -> Réflexions sur le timing de la quantité
-            h\\'e1llo -> h\\'allo
+    @CsvSource(textBlock = """
+            '' , ''
+            hallo , hallo
+            R\\u233eflexions sur le timing de la quantit\\u233e , Réflexions sur le timing de la quantité
+            h\\'e1llo , h\\'allo
             """)
     void basicFormat(String expected, String input) {
         assertEquals(expected, formatter.format(input));
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            {\\i hallo} -> \\emph{hallo}
-            {\\i hallo} -> {\\emph hallo}
-            An article title with {\\i a book title} emphasized -> An article title with \\emph{a book title} emphasized
-            {\\i hallo} -> \\textit{hallo}
-            {\\i hallo} -> {\\textit hallo}
-            {\\b hallo} -> \\textbf{hallo}
-            {\\b hallo} -> {\\textbf hallo}
+    @CsvSource(textBlock = """
+            {\\i hallo} , \\emph{hallo}
+            {\\i hallo} , {\\emph hallo}
+            An article title with {\\i a book title} emphasized , An article title with \\emph{a book title} emphasized
+            {\\i hallo} , \\textit{hallo}
+            {\\i hallo} , {\\textit hallo}
+            {\\b hallo} , \\textbf{hallo}
+            {\\b hallo} , {\\textbf hallo}
             """)
     void laTeXHighlighting(String expected, String input) {
         assertEquals(expected, formatter.format(input));
@@ -144,97 +144,97 @@ class RTFCharsTest {
     }
 
     @ParameterizedTest(name = "specialChar={0}, formattedStr={1}")
-    @CsvSource(delimiterString = "->", textBlock = """
+    @CsvSource(textBlock = """
             # A
-            ÀÁÂÃÄĀĂĄ -> \\u192A\\u193A\\u194A\\u195A\\u196A\\u256A\\u258A\\u260A
+            ÀÁÂÃÄĀĂĄ , \\u192A\\u193A\\u194A\\u195A\\u196A\\u256A\\u258A\\u260A
             # a
-            àáâãäåāăą -> \\u224a\\u225a\\u226a\\u227a\\u228a\\u229a\\u257a\\u259a\\u261a
+            àáâãäåāăą , \\u224a\\u225a\\u226a\\u227a\\u228a\\u229a\\u257a\\u259a\\u261a
             # C
-            ÇĆĈĊČ -> \\u199C\\u262C\\u264C\\u266C\\u268C
+            ÇĆĈĊČ , \\u199C\\u262C\\u264C\\u266C\\u268C
             # c
-            çćĉċč -> \\u231c\\u263c\\u265c\\u267c\\u269c
+            çćĉċč , \\u231c\\u263c\\u265c\\u267c\\u269c
             # D
-            ÐĐ -> \\u208D\\u272D
+            ÐĐ , \\u208D\\u272D
             # d
-            ðđ -> \\u240d\\u273d
+            ðđ , \\u240d\\u273d
             # E
-            ÈÉÊËĒĔĖĘĚ -> \\u200E\\u201E\\u202E\\u203E\\u274E\\u276E\\u278E\\u280E\\u282E
+            ÈÉÊËĒĔĖĘĚ , \\u200E\\u201E\\u202E\\u203E\\u274E\\u276E\\u278E\\u280E\\u282E
             # e
-            èéêëēĕėęě -> \\u232e\\u233e\\u234e\\u235e\\u275e\\u277e\\u279e\\u281e\\u283e
+            èéêëēĕėęě , \\u232e\\u233e\\u234e\\u235e\\u275e\\u277e\\u279e\\u281e\\u283e
             # G
-            ĜĞĠĢŊ -> \\u284G\\u286G\\u288G\\u290G\\u330G
+            ĜĞĠĢŊ , \\u284G\\u286G\\u288G\\u290G\\u330G
             # g
-            ĝğġģŋ -> \\u285g\\u287g\\u289g\\u291g\\u331g
+            ĝğġģŋ , \\u285g\\u287g\\u289g\\u291g\\u331g
             # H
-            ĤĦ -> \\u292H\\u294H
+            ĤĦ , \\u292H\\u294H
             # h
-            ĥħ -> \\u293h\\u295h
+            ĥħ , \\u293h\\u295h
             # I
-            ÌÍÎÏĨĪĬĮİ -> \\u204I\\u205I\\u206I\\u207I\\u296I\\u298I\\u300I\\u302I\\u304I
+            ÌÍÎÏĨĪĬĮİ , \\u204I\\u205I\\u206I\\u207I\\u296I\\u298I\\u300I\\u302I\\u304I
             # i
-            ìíîïĩīĭį -> \\u236i\\u237i\\u238i\\u239i\\u297i\\u299i\\u301i\\u303i
+            ìíîïĩīĭį , \\u236i\\u237i\\u238i\\u239i\\u297i\\u299i\\u301i\\u303i
             # J
-            Ĵ -> \\u308J
+            Ĵ , \\u308J
             # j
-            ĵ -> \\u309j
+            ĵ , \\u309j
             # K
-            Ķ -> \\u310K
+            Ķ , \\u310K
             # k
-            ķ -> \\u311k
+            ķ , \\u311k
             # L
-            ĹĻĿ -> \\u313L\\u315L\\u319L
+            ĹĻĿ , \\u313L\\u315L\\u319L
             # l
-            ĺļŀł -> \\u314l\\u316l\\u320l\\u322l
+            ĺļŀł , \\u314l\\u316l\\u320l\\u322l
             # N
-            ÑŃŅŇ -> \\u209N\\u323N\\u325N\\u327N
+            ÑŃŅŇ , \\u209N\\u323N\\u325N\\u327N
             # n
-            ñńņň -> \\u241n\\u324n\\u326n\\u328n
+            ñńņň , \\u241n\\u324n\\u326n\\u328n
             # O
-            ÒÓÔÕÖØŌŎ -> \\u210O\\u211O\\u212O\\u213O\\u214O\\u216O\\u332O\\u334O
+            ÒÓÔÕÖØŌŎ , \\u210O\\u211O\\u212O\\u213O\\u214O\\u216O\\u332O\\u334O
             # o
-            òóôõöøōŏ -> \\u242o\\u243o\\u244o\\u245o\\u246o\\u248o\\u333o\\u335o
+            òóôõöøōŏ , \\u242o\\u243o\\u244o\\u245o\\u246o\\u248o\\u333o\\u335o
             # R
-            ŔŖŘ -> \\u340R\\u342R\\u344R
+            ŔŖŘ , \\u340R\\u342R\\u344R
             # r
-            ŕŗř -> \\u341r\\u343r\\u345r
+            ŕŗř , \\u341r\\u343r\\u345r
             # S
-            ŚŜŞŠ -> \\u346S\\u348S\\u350S\\u352S
+            ŚŜŞŠ , \\u346S\\u348S\\u350S\\u352S
             # s
-            śŝşš -> \\u347s\\u349s\\u351s\\u353s
+            śŝşš , \\u347s\\u349s\\u351s\\u353s
             # T
-            ŢŤŦ -> \\u354T\\u356T\\u358T
+            ŢŤŦ , \\u354T\\u356T\\u358T
             # t
-            ţŧ -> \\u355t\\u359t
+            ţŧ , \\u355t\\u359t
             # U
-            ÙÚÛÜŨŪŬŮŲ -> \\u217U\\u218U\\u219U\\u220U\\u360U\\u362U\\u364U\\u366U\\u370U
+            ÙÚÛÜŨŪŬŮŲ , \\u217U\\u218U\\u219U\\u220U\\u360U\\u362U\\u364U\\u366U\\u370U
             # u
-            ùúûũūŭůų -> \\u249u\\u250u\\u251u\\u361u\\u363u\\u365u\\u367u\\u371u
+            ùúûũūŭůų , \\u249u\\u250u\\u251u\\u361u\\u363u\\u365u\\u367u\\u371u
             # W
-            Ŵ -> \\u372W
+            Ŵ , \\u372W
             # w
-            ŵ -> \\u373w
+            ŵ , \\u373w
             # Y
-            ŶŸÝ -> \\u374Y\\u376Y\\u221Y
+            ŶŸÝ , \\u374Y\\u376Y\\u221Y
             # y
-            ŷÿ -> \\u375y\\u255y
+            ŷÿ , \\u375y\\u255y
             # Z
-            ŹŻŽ -> \\u377Z\\u379Z\\u381Z
+            ŹŻŽ , \\u377Z\\u379Z\\u381Z
             # z
-            źżž -> \\u378z\\u380z\\u382z
+            źżž , \\u378z\\u380z\\u382z
             # AE
-            Æ -> \\u198AE
+            Æ , \\u198AE
             # ae
-            æ -> \\u230ae
+            æ , \\u230ae
             # OE
-            Œ -> \\u338OE
+            Œ , \\u338OE
             # oe
-            œ -> \\u339oe
+            œ , \\u339oe
             # TH
-            Þ -> \\u222TH
+            Þ , \\u222TH
             # ss
-            ß -> \\u223ss
+            ß , \\u223ss
             # !
-            ¡ -> \\u161!
+            ¡ , \\u161!
             """)
     void moreSpecialCharacters(String specialChar, String expectedResult) {
         String formattedStr = formatter.format(specialChar);
@@ -242,62 +242,62 @@ class RTFCharsTest {
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-             \\'e0-> \\`{a}
-             \\'e8-> \\`{e}
-             \\'ec-> \\`{i}
-             \\'f2-> \\`{o}
-             \\'f9-> \\`{u}
+    @CsvSource(textBlock = """
+             \\'e0, \\`{a}
+             \\'e8, \\`{e}
+             \\'ec, \\`{i}
+             \\'f2, \\`{o}
+             \\'f9, \\`{u}
 
-             \\'e1-> \\'a
-             \\'e9-> \\'e
-             \\'ed-> \\'i
-             \\'f3-> \\'o
-             \\'fa-> \\'u
+             \\'e1, \\'a
+             \\'e9, \\'e
+             \\'ed, \\'i
+             \\'f3, \\'o
+             \\'fa, \\'u
 
-             \\'e2-> \\^a
-             \\'ea-> \\^e
-             \\'ee-> \\^i
-             \\'f4-> \\^o
-             \\'fa-> \\^u
+             \\'e2, \\^a
+             \\'ea, \\^e
+             \\'ee, \\^i
+             \\'f4, \\^o
+             \\'fa, \\^u
 
-             \\'e4-> \\\"a
-             \\'eb-> \\\"e
-             \\'ef-> \\\"i
-             \\'f6-> \\\"o
-             \\u252u-> \\\"u
+             \\'e4, \\\"a
+             \\'eb, \\\"e
+             \\'ef, \\\"i
+             \\'f6, \\\"o
+             \\u252u, \\\"u
 
-             \\'f1-> \\~n
+             \\'f1, \\~n
             """)
     void rtfCharacters(String expected, String input) {
         assertEquals(expected, formatter.format(input));
     }
 
     @ParameterizedTest
-    @CsvSource(delimiterString = "->", textBlock = """
-            \\'c0 -> \\`A
-            \\'c8 -> \\`E
-            \\'cc -> \\`I
-            \\'d2 -> \\`O
-            \\'d9 -> \\`U
+    @CsvSource(textBlock = """
+            \\'c0 , \\`A
+            \\'c8 , \\`E
+            \\'cc , \\`I
+            \\'d2 , \\`O
+            \\'d9 , \\`U
 
-            \\'c1 -> \\'A
-            \\'c9 -> \\'E
-            \\'cd -> \\'I
-            \\'d3 -> \\'O
-            \\'da -> \\'U
+            \\'c1 , \\'A
+            \\'c9 , \\'E
+            \\'cd , \\'I
+            \\'d3 , \\'O
+            \\'da , \\'U
 
-            \\'c2 -> \\^A
-            \\'ca -> \\^E
-            \\'ce -> \\^I
-            \\'d4 -> \\^O
-            \\'db -> \\^U
+            \\'c2 , \\^A
+            \\'ca , \\^E
+            \\'ce , \\^I
+            \\'d4 , \\^O
+            \\'db , \\^U
 
-            \\'c4 -> \\\"A
-            \\'cb -> \\\"E
-            \\'cf -> \\\"I
-            \\'d6 -> \\\"O
-            \\'dc -> \\\"U
+            \\'c4 , \\\"A
+            \\'cb , \\\"E
+            \\'cf , \\\"I
+            \\'d6 , \\\"O
+            \\'dc , \\\"U
             """)
     void rTFCharactersCapital(String expected, String input) {
         assertEquals(expected, formatter.format(input));

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -248,25 +248,21 @@ class RTFCharsTest {
              \\'ec, \\`{i}
              \\'f2, \\`{o}
              \\'f9, \\`{u}
-
              \\'e1, \\'a
              \\'e9, \\'e
              \\'ed, \\'i
              \\'f3, \\'o
              \\'fa, \\'u
-
              \\'e2, \\^a
              \\'ea, \\^e
              \\'ee, \\^i
              \\'f4, \\^o
              \\'fa, \\^u
-
              \\'e4, \\\"a
              \\'eb, \\\"e
              \\'ef, \\\"i
              \\'f6, \\\"o
              \\u252u, \\\"u
-
              \\'f1, \\~n
             """)
     void rtfCharacters(String expected, String input) {
@@ -280,19 +276,16 @@ class RTFCharsTest {
             \\'cc , \\`I
             \\'d2 , \\`O
             \\'d9 , \\`U
-
             \\'c1 , \\'A
             \\'c9 , \\'E
             \\'cd , \\'I
             \\'d3 , \\'O
             \\'da , \\'U
-
             \\'c2 , \\^A
             \\'ca , \\^E
             \\'ce , \\^I
             \\'d4 , \\^O
             \\'db , \\^U
-
             \\'c4 , \\\"A
             \\'cb , \\\"E
             \\'cf , \\\"I

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -29,10 +29,10 @@ class RTFCharsTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            '' , ''
-            hallo , hallo
-            R\\u233eflexions sur le timing de la quantit\\u233e , Réflexions sur le timing de la quantité
-            h\\'e1llo , h\\'allo
+            '', ''
+            hallo, hallo
+            R\\u233eflexions sur le timing de la quantit\\u233e, Réflexions sur le timing de la quantité
+            h\\'e1llo, h\\'allo
             """)
     void basicFormat(String expected, String input) {
         assertEquals(expected, formatter.format(input));
@@ -40,13 +40,13 @@ class RTFCharsTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            {\\i hallo} , \\emph{hallo}
-            {\\i hallo} , {\\emph hallo}
-            An article title with {\\i a book title} emphasized , An article title with \\emph{a book title} emphasized
-            {\\i hallo} , \\textit{hallo}
-            {\\i hallo} , {\\textit hallo}
-            {\\b hallo} , \\textbf{hallo}
-            {\\b hallo} , {\\textbf hallo}
+            {\\i hallo}, \\emph{hallo}
+            {\\i hallo}, {\\emph hallo}
+            An article title with {\\i a book title} emphasized, An article title with \\emph{a book title} emphasized
+            {\\i hallo}, \\textit{hallo}
+            {\\i hallo}, {\\textit hallo}
+            {\\b hallo}, \\textbf{hallo}
+            {\\b hallo}, {\\textbf hallo}
             """)
     void laTeXHighlighting(String expected, String input) {
         assertEquals(expected, formatter.format(input));
@@ -146,95 +146,95 @@ class RTFCharsTest {
     @ParameterizedTest(name = "specialChar={0}, formattedStr={1}")
     @CsvSource(textBlock = """
             # A
-            ÀÁÂÃÄĀĂĄ , \\u192A\\u193A\\u194A\\u195A\\u196A\\u256A\\u258A\\u260A
+            ÀÁÂÃÄĀĂĄ, \\u192A\\u193A\\u194A\\u195A\\u196A\\u256A\\u258A\\u260A
             # a
-            àáâãäåāăą , \\u224a\\u225a\\u226a\\u227a\\u228a\\u229a\\u257a\\u259a\\u261a
+            àáâãäåāăą, \\u224a\\u225a\\u226a\\u227a\\u228a\\u229a\\u257a\\u259a\\u261a
             # C
-            ÇĆĈĊČ , \\u199C\\u262C\\u264C\\u266C\\u268C
+            ÇĆĈĊČ, \\u199C\\u262C\\u264C\\u266C\\u268C
             # c
-            çćĉċč , \\u231c\\u263c\\u265c\\u267c\\u269c
+            çćĉċč, \\u231c\\u263c\\u265c\\u267c\\u269c
             # D
-            ÐĐ , \\u208D\\u272D
+            ÐĐ, \\u208D\\u272D
             # d
-            ðđ , \\u240d\\u273d
+            ðđ, \\u240d\\u273d
             # E
-            ÈÉÊËĒĔĖĘĚ , \\u200E\\u201E\\u202E\\u203E\\u274E\\u276E\\u278E\\u280E\\u282E
+            ÈÉÊËĒĔĖĘĚ, \\u200E\\u201E\\u202E\\u203E\\u274E\\u276E\\u278E\\u280E\\u282E
             # e
-            èéêëēĕėęě , \\u232e\\u233e\\u234e\\u235e\\u275e\\u277e\\u279e\\u281e\\u283e
+            èéêëēĕėęě, \\u232e\\u233e\\u234e\\u235e\\u275e\\u277e\\u279e\\u281e\\u283e
             # G
-            ĜĞĠĢŊ , \\u284G\\u286G\\u288G\\u290G\\u330G
+            ĜĞĠĢŊ, \\u284G\\u286G\\u288G\\u290G\\u330G
             # g
-            ĝğġģŋ , \\u285g\\u287g\\u289g\\u291g\\u331g
+            ĝğġģŋ, \\u285g\\u287g\\u289g\\u291g\\u331g
             # H
-            ĤĦ , \\u292H\\u294H
+            ĤĦ, \\u292H\\u294H
             # h
-            ĥħ , \\u293h\\u295h
+            ĥħ, \\u293h\\u295h
             # I
-            ÌÍÎÏĨĪĬĮİ , \\u204I\\u205I\\u206I\\u207I\\u296I\\u298I\\u300I\\u302I\\u304I
+            ÌÍÎÏĨĪĬĮİ, \\u204I\\u205I\\u206I\\u207I\\u296I\\u298I\\u300I\\u302I\\u304I
             # i
-            ìíîïĩīĭį , \\u236i\\u237i\\u238i\\u239i\\u297i\\u299i\\u301i\\u303i
+            ìíîïĩīĭį, \\u236i\\u237i\\u238i\\u239i\\u297i\\u299i\\u301i\\u303i
             # J
-            Ĵ , \\u308J
+            Ĵ, \\u308J
             # j
-            ĵ , \\u309j
+            ĵ, \\u309j
             # K
-            Ķ , \\u310K
+            Ķ, \\u310K
             # k
-            ķ , \\u311k
+            ķ, \\u311k
             # L
-            ĹĻĿ , \\u313L\\u315L\\u319L
+            ĹĻĿ, \\u313L\\u315L\\u319L
             # l
-            ĺļŀł , \\u314l\\u316l\\u320l\\u322l
+            ĺļŀł, \\u314l\\u316l\\u320l\\u322l
             # N
-            ÑŃŅŇ , \\u209N\\u323N\\u325N\\u327N
+            ÑŃŅŇ, \\u209N\\u323N\\u325N\\u327N
             # n
-            ñńņň , \\u241n\\u324n\\u326n\\u328n
+            ñńņň, \\u241n\\u324n\\u326n\\u328n
             # O
-            ÒÓÔÕÖØŌŎ , \\u210O\\u211O\\u212O\\u213O\\u214O\\u216O\\u332O\\u334O
+            ÒÓÔÕÖØŌŎ, \\u210O\\u211O\\u212O\\u213O\\u214O\\u216O\\u332O\\u334O
             # o
-            òóôõöøōŏ , \\u242o\\u243o\\u244o\\u245o\\u246o\\u248o\\u333o\\u335o
+            òóôõöøōŏ, \\u242o\\u243o\\u244o\\u245o\\u246o\\u248o\\u333o\\u335o
             # R
-            ŔŖŘ , \\u340R\\u342R\\u344R
+            ŔŖŘ, \\u340R\\u342R\\u344R
             # r
-            ŕŗř , \\u341r\\u343r\\u345r
+            ŕŗř, \\u341r\\u343r\\u345r
             # S
-            ŚŜŞŠ , \\u346S\\u348S\\u350S\\u352S
+            ŚŜŞŠ, \\u346S\\u348S\\u350S\\u352S
             # s
-            śŝşš , \\u347s\\u349s\\u351s\\u353s
+            śŝşš, \\u347s\\u349s\\u351s\\u353s
             # T
-            ŢŤŦ , \\u354T\\u356T\\u358T
+            ŢŤŦ, \\u354T\\u356T\\u358T
             # t
-            ţŧ , \\u355t\\u359t
+            ţŧ, \\u355t\\u359t
             # U
-            ÙÚÛÜŨŪŬŮŲ , \\u217U\\u218U\\u219U\\u220U\\u360U\\u362U\\u364U\\u366U\\u370U
+            ÙÚÛÜŨŪŬŮŲ, \\u217U\\u218U\\u219U\\u220U\\u360U\\u362U\\u364U\\u366U\\u370U
             # u
-            ùúûũūŭůų , \\u249u\\u250u\\u251u\\u361u\\u363u\\u365u\\u367u\\u371u
+            ùúûũūŭůų, \\u249u\\u250u\\u251u\\u361u\\u363u\\u365u\\u367u\\u371u
             # W
-            Ŵ , \\u372W
+            Ŵ, \\u372W
             # w
-            ŵ , \\u373w
+            ŵ, \\u373w
             # Y
-            ŶŸÝ , \\u374Y\\u376Y\\u221Y
+            ŶŸÝ, \\u374Y\\u376Y\\u221Y
             # y
-            ŷÿ , \\u375y\\u255y
+            ŷÿ, \\u375y\\u255y
             # Z
-            ŹŻŽ , \\u377Z\\u379Z\\u381Z
+            ŹŻŽ, \\u377Z\\u379Z\\u381Z
             # z
-            źżž , \\u378z\\u380z\\u382z
+            źżž, \\u378z\\u380z\\u382z
             # AE
-            Æ , \\u198AE
+            Æ, \\u198AE
             # ae
-            æ , \\u230ae
+            æ, \\u230ae
             # OE
-            Œ , \\u338OE
+            Œ, \\u338OE
             # oe
-            œ , \\u339oe
+            œ, \\u339oe
             # TH
-            Þ , \\u222TH
+            Þ, \\u222TH
             # ss
-            ß , \\u223ss
+            ß, \\u223ss
             # !
-            ¡ , \\u161!
+            ¡, \\u161!
             """)
     void moreSpecialCharacters(String specialChar, String expectedResult) {
         String formattedStr = formatter.format(specialChar);
@@ -271,26 +271,26 @@ class RTFCharsTest {
 
     @ParameterizedTest
     @CsvSource(textBlock = """
-            \\'c0 , \\`A
-            \\'c8 , \\`E
-            \\'cc , \\`I
-            \\'d2 , \\`O
-            \\'d9 , \\`U
-            \\'c1 , \\'A
-            \\'c9 , \\'E
-            \\'cd , \\'I
-            \\'d3 , \\'O
-            \\'da , \\'U
-            \\'c2 , \\^A
-            \\'ca , \\^E
-            \\'ce , \\^I
-            \\'d4 , \\^O
-            \\'db , \\^U
-            \\'c4 , \\\"A
-            \\'cb , \\\"E
-            \\'cf , \\\"I
-            \\'d6 , \\\"O
-            \\'dc , \\\"U
+            \\'c0, \\`A
+            \\'c8, \\`E
+            \\'cc, \\`I
+            \\'d2, \\`O
+            \\'d9, \\`U
+            \\'c1, \\'A
+            \\'c9, \\'E
+            \\'cd, \\'I
+            \\'d3, \\'O
+            \\'da, \\'U
+            \\'c2, \\^A
+            \\'ca, \\^E
+            \\'ce, \\^I
+            \\'d4, \\^O
+            \\'db, \\^U
+            \\'c4, \\\"A
+            \\'cb, \\\"E
+            \\'cf, \\\"I
+            \\'d6, \\\"O
+            \\'dc, \\\"U
             """)
     void rTFCharactersCapital(String expected, String input) {
         assertEquals(expected, formatter.format(input));

--- a/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
+++ b/jablib/src/test/java/org/jabref/logic/layout/format/RTFCharsTest.java
@@ -1,16 +1,12 @@
 package org.jabref.logic.layout.format;
 
-import java.util.stream.Stream;
-
 import org.jabref.logic.layout.LayoutFormatter;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -96,49 +92,72 @@ class RTFCharsTest {
                 formatter.format("Pchnąć w tę łódź jeża lub ośm skrzyń fig"));
     }
 
-    static Stream<Arguments> specialCharacterCases() {
-        return Stream.of(
-                Arguments.of("\\'f3", "\\'{o}"), // ó
-                Arguments.of("\\'f2", "\\`{o}"), // ò
-                Arguments.of("\\'f4", "\\^{o}"), // ô
-                Arguments.of("\\'f6", "\\\"{o}"), // ö
-                Arguments.of("\\u245o", "\\~{o}"), // õ
-                Arguments.of("\\u333o", "\\={o}"),
-                Arguments.of("\\u335o", "{\\uo}"),
-                Arguments.of("\\u231c", "{\\cc}"), // ç
-                Arguments.of("{\\u339oe}", "{\\oe}"),
-                Arguments.of("{\\u338OE}", "{\\OE}"),
-                Arguments.of("{\\u230ae}", "{\\ae}"), // æ
-                Arguments.of("{\\u198AE}", "{\\AE}"), // Æ
-
-                Arguments.of("", "\\.{o}"), // ???
-                Arguments.of("", "\\vo"), // ???
-                Arguments.of("", "\\Ha"), // ã // ???
-                Arguments.of("", "\\too"),
-                Arguments.of("", "\\do"), // ???
-                Arguments.of("", "\\bo"), // ???
-
-                Arguments.of("\\u229a", "{\\aa}"), // å
-                Arguments.of("\\u197A", "{\\AA}"), // Å
-                Arguments.of("\\u248o", "{\\o}"), // ø
-                Arguments.of("\\u216O", "{\\O}"), // Ø
-                Arguments.of("\\u322l", "{\\l}"),
-                Arguments.of("\\u321L", "{\\L}"),
-                Arguments.of("\\u223ss", "{\\ss}"), // ß
-                Arguments.of("\\u191?", "\\`?"), // ¿
-                Arguments.of("\\u161!", "\\`!"), // ¡
-
-                Arguments.of("", "\\dag"),
-                Arguments.of("", "\\ddag"),
-                Arguments.of("\\u167S", "{\\S}"), // §
-                Arguments.of("\\u182P", "{\\P}"), // ¶
-                Arguments.of("\\u169?", "{\\copyright}"), // ©
-                Arguments.of("\\u163?", "{\\pounds}") // £
-        );
-    }
-
     @ParameterizedTest
-    @MethodSource("specialCharacterCases")
+    @CsvSource(
+            quoteCharacter = '"',
+            textBlock = """
+                    # ó
+                    "\\'f3",        "\\'{o}"
+                    # ò
+                    "\\'f2",        "\\`{o}"
+                    # ô
+                    "\\'f4",        "\\^{o}"
+                    # ö
+                    "\\'f6",        "\\""{o}"
+                    # õ
+                    "\\u245o",      "\\~{o}"
+                    "\\u333o",      "\\={o}"
+                    "\\u335o",      "{\\uo}"
+                    # ç
+                    "\\u231c",      "{\\cc}"
+                    "{\\u339oe}",   "{\\oe}"
+                    "{\\u338OE}",   "{\\OE}"
+                    # æ
+                    "{\\u230ae}",   "{\\ae}"
+                    # Æ
+                    "{\\u198AE}",   "{\\AE}"
+
+                    # ???
+                    "",             "\\.{o}"
+                    # ???
+                    "",             "\\vo"
+                    # ã // ???
+                    "",             "\\Ha"
+                    "",             "\\too"
+                    # ???
+                    "",             "\\do"
+                    # ???
+                    "",             "\\bo"
+
+                    # å
+                    "\\u229a",      "{\\aa}"
+                    # Å
+                    "\\u197A",      "{\\AA}"
+                    # ø
+                    "\\u248o",      "{\\o}"
+                    # Ø
+                    "\\u216O",      "{\\O}"
+                    "\\u322l",      "{\\l}"
+                    "\\u321L",      "{\\L}"
+                    # ß
+                    "\\u223ss",     "{\\ss}"
+                    # ¿
+                    "\\u191?",      "\\`?"
+                    # ¡
+                    "\\u161!",      "\\`!"
+
+                    "",             "\\dag"
+                    "",             "\\ddag"
+                    # §
+                    "\\u167S",      "{\\S}"
+                    # ¶
+                    "\\u182P",      "{\\P}"
+                    # ©
+                    "\\u169?",      "{\\copyright}"
+                    # £
+                    "\\u163?",      "{\\pounds}"
+                    """
+    )
     void specialCharacters(String expected, String input) {
         assertEquals(expected, formatter.format(input));
     }


### PR DESCRIPTION
Closes #676

This PR refactors several unit tests in the jablib/src/test/java/org/jabref/logic/layout/format/ package to use JUnit 5 parameterized tests.
The goal is to simplify repetitive test logic, improve readability, and make future additions to formatting rules easier to maintain.

### Steps to test
1. Build JabRef as usual
2. Confirm that the following tests pass:
  - AuthorAndsCommaReplacerTest
  - AuthorFirstAbbrLastCommasTest
  - AuthorLastFirstAbbrCommasTest
  - AuthorLastFirstOxfordCommasTest
  - RTFCharsTest
  - LayoutEntryTest
3. Verify that test output and behavior are unchanged.

### Mandatory checks

- [x] I own the copyright of the code submitted and I license it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [/] I manually tested my changes in running JabRef (always required)
- [/] I added JUnit tests for changes (refactored existing ones)
- [/] I added screenshots in the PR description (if change is visible to the user)
- [/] I described the change in `CHANGELOG.md` in a way that is understandable for the average user (if change is visible to the user)
- [/] I checked the [user documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request updating file(s) in <https://github.com/JabRef/user-documentation/tree/main/en>.
